### PR TITLE
cli: enable support for progname to be an atom

### DIFF
--- a/test/argparse_SUITE.erl
+++ b/test/argparse_SUITE.erl
@@ -132,6 +132,11 @@ readme(Config) when is_list(Config) ->
     %% override progname
     ?assertEqual("usage: readme\n",
         argparse:help(#{}, #{progname => "readme"})),
+    ?assertEqual("usage: readme\n",
+        argparse:help(#{}, #{progname => readme})),
+    ?assertException(error, {argparse,
+        {invalid_command, [], progname, "progname must be a list or an atom"}},
+        argparse:help(#{}, #{progname => 123})),
     %% command example
     Cmd = #{
         commands => #{"sub" => #{}},


### PR DESCRIPTION
As requested in issue #1, progname as an atom could be quite
convenient.