### PR TITLE
argparse: add --arg=value form for long options

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,10 @@ rebar3.
     {deps, [argparse]}.
 ```
 
-## Known incompatibilities:
-  * boolean flag (option), automatically using {store, true}
-  * all positional arguments are required by default (even 'maybe')
+## Known incompatibilities
+In comparison with Python implementation, `argparse` for Erlang:
+  * boolean flag (option) automatically uses {store, true}
+  * all positional arguments are required by default (even when nargs is 'maybe')
   * first-class (sub) commands, slightly differently from argparse
   * implicit --help/-h is not a part of argparse (but implemented in cli)
 
@@ -170,7 +171,7 @@ over a positional argument.
 Commands form exclusive groups, e.g. only one command can
 be followed at a time.
 
-Kinds of arguments supported:
+## Supported command line syntax
  * command (priority positional argument) : ectl {crawler|reader|writer}
  * command, and sub-command:                ectl crawler {start|stop|check}
  * positional argument (required):          ectl <arg1> <arg2>
@@ -183,20 +184,23 @@ Kinds of arguments supported:
  * long option flag:          ectl [--foo]
  * long optional argument:    ectl [--foo <arg>]
  * required long:             ectl --foo <arg>
+ * long, arg=value form:      ectl --foo=arg
  * list of arguments:         ectl <arg>, ...
 
 ## Expected features
 
-To be considered after 1.0.0:
+To be considered after 1.1.2:
 * search for commands and arguments (mini-man)
 * abbreviated long forms
 * mutual exclusion groups
 * handler hooks (global options support)
 * shell auto-complete
-* support for "--arg=value" form
 * automatically generated negative boolean long forms "--no-XXXX"
 
 ## Changelog
+
+Version 1.1.2:
+ * support for "--arg=value" form
 
 Version 1.1.1:
  * added templates for help text

--- a/doc/ARGPARSE.md
+++ b/doc/ARGPARSE.md
@@ -114,7 +114,7 @@ character is automatically prepended to long forms, so for this example:
 ```erlang
     #{name => myarg, short => $m, long => "-myarg"}
 ```
-Argument ```myarg``` can be specified as ```-m``` or as ```--myarg```. Please not that it
+Argument ```myarg``` can be specified as ```-m``` or as ```--myarg```. Please note that it
 is possible to have long forms with a single prefix character:
 ```erlang
     #{name => kernel, long => "kernel"}
@@ -122,6 +122,12 @@ is possible to have long forms with a single prefix character:
 By default, optional arguments are not required and may be omitted from command line.
 Positional arguments are required. It is possible to override this behaviour by
 setting **required** field.
+
+It is supported to specify long-form value using this syntax:
+```shell
+    mycli --arg=value
+```
+It is treated the same way as `mycli --arg value`.
 
 For every argument matched, parser may consume several following positional arguments
 (not starting with a prefix). Analysis is based on **nargs**, **action** and **type** fields.

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -1,6 +1,6 @@
  ** this is the overview.doc file for the application 'argparse' **
 
-   @version 1.1.1
+   @version 1.1.2
    @author Maxim Fedorov, <maximfca@gmail.com>
    @title argparse: A simple framework to create complex CLI.
 

--- a/src/argparse.app.src
+++ b/src/argparse.app.src
@@ -1,6 +1,6 @@
 {application, argparse,
  [{description, "argparse: arguments parser, and cli framework"},
-  {vsn, "1.1.1"},
+  {vsn, "1.1.2"},
   {applications,
    [kernel,
     stdlib

--- a/test/argparse_SUITE.erl
+++ b/test/argparse_SUITE.erl
@@ -10,6 +10,7 @@
 
 -export([
     basic/0, basic/1,
+    long_form_eq/0, long_form_eq/1,
     single_arg_built_in_types/0, single_arg_built_in_types/1,
     complex_command/0, complex_command/1,
     errors/0, errors/1,
@@ -39,7 +40,8 @@ suite() ->
 
 groups() ->
     [{parallel, [parallel], [
-        basic, single_arg_built_in_types, complex_command, errors, args, argparse, negative,
+        basic, long_form_eq, single_arg_built_in_types, complex_command, errors,
+        args, argparse, negative,
         nodigits,  python_issue_15112, type_validators, subcommand, error_format,
         very_short, multi_short, usage, readme, error_usage, meta, usage_template
     ]}].
@@ -178,6 +180,17 @@ basic(Config) when is_list(Config) ->
     ArgList = #{name => arg, nargs => 2, type => boolean},
     ?assertEqual(#{arg => [true, false]},
         parse(["true false"], #{arguments => [ArgList]})).
+
+long_form_eq() ->
+    [{doc, "Tests that long form supports --arg=value"}].
+
+long_form_eq(Config) when is_list(Config) ->
+    %% cmd --arg=value
+    PosOptCmd = #{arguments => [#{name => arg, long => "-arg"}]},
+    ?assertEqual({#{arg => "value"}, {["cmd"], PosOptCmd}},
+        parse(["cmd --arg=value"], #{commands => #{"cmd" => PosOptCmd}})),
+    %% --int=10
+    ?assertEqual(#{int => 10}, parse(["--int=10"], #{arguments => [#{name => int, type => int, long => "-int"}]})).
 
 single_arg_built_in_types() ->
     [{doc, "Tests all built-in types supplied as a single argument"}].


### PR DESCRIPTION
Implements #12.