### PR TITLE
argparse: fix bug causing nargs => all to malfunction

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,15 +189,16 @@ be followed at a time.
 
 ## Expected features
 
-To be considered after 1.1.2:
+To be considered after 1.1.3:
 * search for commands and arguments (mini-man)
 * abbreviated long forms
 * mutual exclusion groups
-* handler hooks (global options support)
 * shell auto-complete
 * automatically generated negative boolean long forms "--no-XXXX"
 
 ## Changelog
+Version 1.1.3:
+* fixed bug causing `nargs => all` to be ignored
 
 Version 1.1.2:
  * support for "--arg=value" form

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -1,6 +1,6 @@
  ** this is the overview.doc file for the application 'argparse' **
 
-   @version 1.1.2
+   @version 1.1.3
    @author Maxim Fedorov, <maximfca@gmail.com>
    @title argparse: A simple framework to create complex CLI.
 

--- a/src/argparse.app.src
+++ b/src/argparse.app.src
@@ -1,6 +1,6 @@
 {application, argparse,
  [{description, "argparse: arguments parser, and cli framework"},
-  {vsn, "1.1.2"},
+  {vsn, "1.1.3"},
   {applications,
    [kernel,
     stdlib


### PR DESCRIPTION
Positional argument with nargs => all is expected to catch all
arguments that are not recognised, and put them into a single
map entry. However it wasn't working when unrecognised argument
was optional argument, e.g. "erl -app1 key value"