### PR TITLE
argparse: improve help/usage options

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ To be considered after 1.1.3:
 
 ## Changelog
 Version 1.1.3:
-* fixed bug causing `nargs => all` to be ignored
+ * added `help => hidden` for commands and options
+ * changed default formatting for better readability
+ * fixed bug causing `nargs => all` to be ignored
 
 Version 1.1.2:
  * support for "--arg=value" form

--- a/doc/ARGPARSE.md
+++ b/doc/ARGPARSE.md
@@ -58,7 +58,7 @@ name, and a sub-spec passed for this command:
 Command specification may contain following fields:
   * **commands** - sub-commands, name to nested command spec
   * **arguments** - list of argument specifications
-  * **help** - string to generate usage information
+  * **help** - string to generate usage information, can be set to `hidden`, causing this command to be omitted in usage output
   * **handler** - function expected to process this command, or *optional* atom
   * user-defined fields
 
@@ -203,6 +203,8 @@ To get human-readable representation:
 ```
 
 ## Help templates
+
+To completely hide the argument or command from the output, supply `help => hidden`.
 
 It is possible to override help text generated for arguments. By default,
 options are formatted with "help text, type, default", e.g.:

--- a/test/cli_SUITE.erl
+++ b/test/cli_SUITE.erl
@@ -214,22 +214,22 @@ auto_help(Config) when is_list(Config) ->
         modules => [?MODULE, auto_help]}) end)),
     %% request help for a subcommand
     Expected2 = "usage: erl math {cos|extra|sin} <in>\n\nSubcommands:\n  cos   "
-        "Calculates cosinus\n  extra \n  sin   \n\nArguments:\n  in Input value, float\n",
+        "Calculates cosinus\n  extra \n  sin   \n\nArguments:\n  in Input value (float)\n",
     ?assertEqual({ok, Expected2}, capture_output(fun () -> cli:run(["math", "--help"],
         #{modules => [?MODULE]}) end)),
     %% request help for a sub-subcommand
     Expected3 = "usage: erl math extra {fail|ok} <in>\n\nSubcommands:\n  fail \n"
-        "  ok   \n\nArguments:\n  in Input value, float\n",
+        "  ok   \n\nArguments:\n  in Input value (float)\n",
     ?assertEqual({ok, Expected3}, capture_output(fun () -> cli:run(["math", "extra", "--help"],
         #{modules => ?MODULE}) end)),
     %% request help for a sub-sub-subcommand
-    Expected4 = "usage: erl math cos <in>\n\nArguments:\n  in Input value, float\n",
+    Expected4 = "usage: erl math cos <in>\n\nArguments:\n  in Input value (float)\n",
     ?assertEqual({ok, Expected4}, capture_output(fun () -> cli:run(["math", "cos", "--help"],
         #{modules => ?MODULE}) end)),
     %% request help in a really wrong way (subcommand does not exist)
     Expected5 =
         "error: erl math: invalid argument bad for: in\nusage: erl math {cos|extra|sin} <in>\n\nSubcommands:\n"
-        "  cos   Calculates cosinus\n  extra \n  sin   \n\nArguments:\n  in Input value, float\n",
+        "  cos   Calculates cosinus\n  extra \n  sin   \n\nArguments:\n  in Input value (float)\n",
     ?assertEqual({ok, Expected5}, capture_output(fun () -> cli:run(["math", "bad", "--help"],
         #{modules => ?MODULE}) end)).
 


### PR DESCRIPTION
Added new option `hidden` that causes argument or command to be omitted when
printing usage.
Changed default formatter template as suggested in #16.