### PR TITLE
[argparse] fix unicode support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,11 @@
 stages:
   - test
+  - deploy
 
 test-default-docker:
   tags:
     - linux
-  image: erlang:latest
+  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/erlang:latest
   stage: test
   script:
     - rebar3 compile
@@ -14,8 +15,21 @@ test-default-docker:
   artifacts:
     when: always
     paths:
-      - "_build/test/logs/last/**"
+      - "_build/test/logs/**"
     expire_in: 3 days
     reports:
       junit:
         - _build/test/logs/last/junit_report.xml
+
+# Pages: publishing Common Test results
+pages:
+  stage: deploy
+  needs:
+    - test-default-docker
+  script:
+    - mv _build/test/logs ./public
+  artifacts:
+    paths:
+      - public
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH


### PR DESCRIPTION
Fixes https://github.com/max-au/argparse/issues/23.
Unicode is expected to be supported in argument named, help texts,
default values and command line.