### PR TITLE
[argparse, cli] implement global default

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -2,12 +2,10 @@ name: Build, Test, Dialyze
 
 on:
   pull_request:
-    branches:
-      - 'master'
+    types: [ opened, reopened, synchronize ]
   push:
     branches:
       - 'master'
-
 jobs:
   linux:
     name: Test on OTP ${{ matrix.otp_version }} and ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ To be considered after 1.2.0:
 ## Changelog
 
 Verson 1.2.1:
+ * implemented global default
+ * minor bugfixes
+
+Verson 1.2.1:
  * minor bugfixes, support for choices of atoms
 
 Version 1.2.0:

--- a/doc/ARGPARSE.md
+++ b/doc/ARGPARSE.md
@@ -19,6 +19,14 @@ To override default optional argument prefix (**-**), use **prefixes** option:
     3> argparse:parse(["+sbwt"], #{arguments => [#{name => mode, short => $s}]}, #{prefixes => "+"}).
     #{mode => "bwt"}
 
+To define a global default for arguments that are not required, use **default** option:
+
+    4> argparse:parse([], #{arguments => [#{name => mode, required => false}]}, #{default => undef}).
+    #{mode => undef}
+
+When global default is not set, resulting argument map does not include keys for arguments
+that are not specified in the command line and there is no locally defined default value.
+
 ## Validation, help & usage information
 
 Function ```validate/1``` may be used to validate command with all sub-commands
@@ -40,8 +48,9 @@ argument names to their values:
 
 This map contains all arguments matching command line passed, initialised with
 corresponding values. If argument is omitted, but default value is specified for it,
-it is added to the map. When no default value specified, and argument is not
-present, corresponding key is not present in the map.
+it is added to the map. When no local default value specified, and argument is not
+present, corresponding key is not present in the map, unless there is a global default
+passed with `parse/3` options.
 
 Missing required (field **required** is set to true for optional arguments,
 or missing for positional) arguments raises an error.

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -121,3 +121,5 @@ to provide correct help/usage line:
 
 cli is able to pass **prefixes** option to argparse (this also changes *-h* and *--help*
 prefix). There are also additional options to explore, see `cli:run/2` function reference.
+
+cli also passes **default** option to argparse.

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -1,6 +1,6 @@
  ** this is the overview.doc file for the application 'argparse' **
 
-   @version 1.2.1
+   @version 1.2.2
    @author Maxim Fedorov, <maximfca@gmail.com>
    @title argparse: A simple framework to create complex CLI.
 

--- a/src/argparse.app.src
+++ b/src/argparse.app.src
@@ -1,6 +1,6 @@
 {application, argparse,
  [{description, "argparse: arguments parser, and cli framework"},
-  {vsn, "1.2.1"},
+  {vsn, "1.2.2"},
   {applications,
    [kernel,
     stdlib

--- a/src/cli.erl
+++ b/src/cli.erl
@@ -80,6 +80,8 @@ run(Args) ->
     help => boolean(),
     error => ok | error | halt | {halt, non_neg_integer()},
     prefixes => [integer()],%% prefixes passed to argparse
+    %% default value for all missing not required arguments
+    default => term(),
     progname => string() | atom()   %% specifies executable name instead of 'erl'
 }.
 

--- a/test/argparse_SUITE.erl
+++ b/test/argparse_SUITE.erl
@@ -21,6 +21,7 @@
     nodigits/0, nodigits/1,
     python_issue_15112/0, python_issue_15112/1,
     default_for_not_required/0, default_for_not_required/1,
+    global_default/0, global_default/1,
     type_validators/0, type_validators/1,
     error_format/0, error_format/1,
     subcommand/0, subcommand/1,
@@ -47,7 +48,8 @@ groups() ->
         basic, long_form_eq, single_arg_built_in_types, complex_command, errors,
         unicode, args, argparse, negative, proxy_arguments, default_for_not_required,
         nodigits,  python_issue_15112, type_validators, subcommand, error_format,
-        very_short, multi_short, usage, readme, error_usage, meta, usage_template
+        very_short, multi_short, usage, readme, error_usage, meta, usage_template,
+        global_default
     ]}].
 
 all() ->
@@ -590,6 +592,13 @@ default_for_not_required() ->
 default_for_not_required(Config) when is_list(Config) ->
     ?assertEqual(#{def => 1}, parse("", #{arguments => [#{name => def, short => $d, required => false, default => 1}]})),
     ?assertEqual(#{def => 1}, parse("", #{arguments => [#{name => def, required => false, default => 1}]})).
+
+global_default() ->
+    [{doc, "Tests that a global default can be enabled for all non-required arguments"}].
+
+global_default(Config) when is_list(Config) ->
+    ?assertEqual(#{def => "global"}, argparse:parse("", #{arguments => [#{name => def, type => int, required => false}]},
+        #{default => "global"})).
 
 subcommand() ->
     [{doc, "Tests subcommands parser"}].

--- a/test/cli_SUITE.erl
+++ b/test/cli_SUITE.erl
@@ -27,6 +27,7 @@
     multi_module/0, multi_module/1,
     warnings/0, warnings/1,
     simple/0, simple/1,
+    global_default/0, global_default/1,
     malformed_behaviour/0, malformed_behaviour/1,
     exit_code/0, exit_code/1
 ]).
@@ -48,7 +49,7 @@ suite() ->
 
 all() ->
     [test_cli, auto_help, subcmd_help, missing_handler, bare_cli, multi_module, warnings,
-        malformed_behaviour, exit_code].
+        malformed_behaviour, exit_code, global_default].
 
 %%--------------------------------------------------------------------
 %% Helpers
@@ -324,6 +325,17 @@ simple(Config) when is_list(Config) ->
     {ok, IO} = capture_output(fun () -> cli:run(["4"], #{modules => simple, error => ok}) end),
     ct:pal("~s", [IO]),
     ?assertEqual("Removing 4 (force: false, recursive: false)\n", IO).
+
+global_default() ->
+    [{doc, "Verifies that global default for maps works"}].
+
+global_default(Config) when is_list(Config) ->
+    CliRet = "#{arguments => [#{name => foo, short => $f}, #{name => bar, short => $b, default => \"1\"}]}",
+    FunExport = "cli/1",
+    FunDefs = "cli(#{foo := Foo, bar := Bar}) -> io:format(\"Foo ~s, bar ~s~n\", [Foo, Bar]).",
+    cli_module(simple, CliRet, FunExport, [FunDefs]),
+    {ok, IO} = capture_output(fun () -> cli:run([], #{modules => simple, error => ok, default => undefined}) end),
+    ?assertEqual("Foo undefined, bar 1\n", IO).
 
 malformed_behaviour() ->
     [{doc, "Tests for cli/0 callback returning invalid command map"}].


### PR DESCRIPTION
It is convenient to have some globally set default for all
missing non-required arguments. Closes #27.