### PR TITLE
[argparse] fix help generation for {atom, unsafe} type

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ To be considered after 1.2.0:
 
 ## Changelog
 
-Verson 1.2.1:
+Verson 1.2.3:
  * implemented global default
  * minor bugfixes
 

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -1,6 +1,6 @@
  ** this is the overview.doc file for the application 'argparse' **
 
-   @version 1.2.2
+   @version 1.2.3
    @author Maxim Fedorov, <maximfca@gmail.com>
    @title argparse: A simple framework to create complex CLI.
 

--- a/src/argparse.app.src
+++ b/src/argparse.app.src
@@ -1,6 +1,6 @@
 {application, argparse,
  [{description, "argparse: arguments parser, and cli framework"},
-  {vsn, "1.2.2"},
+  {vsn, "1.2.3"},
   {applications,
    [kernel,
     stdlib

--- a/src/argparse.erl
+++ b/src/argparse.erl
@@ -1257,6 +1257,10 @@ format_type(#{type := {binary, Re, _}}) when is_binary(Re) ->
     io_lib:format("binary re: ~ts", [Re]);
 format_type(#{type := {StrBin, Choices}}) when StrBin =:= string orelse StrBin =:= binary, is_list(Choices) ->
     io_lib:format("choice: ~ts", [lists:join(", ", Choices)]);
+format_type(#{type := atom}) ->
+    "existing atom";
+format_type(#{type := {atom, unsafe}}) ->
+    "atom";
 format_type(#{type := {atom, Choices}}) ->
     io_lib:format("choice: ~ts", [lists:join(", ", [atom_to_list(C) || C <- Choices])]);
 format_type(#{type := boolean}) ->


### PR DESCRIPTION
Also add corresponding test. Closes #36.