### PR TITLE
[args] Rename argparse module to args

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [21.2, 22, 23, 24, 25]
+        otp_version: [21.2, 22, 23, 24, 25, 26]
         os: [ubuntu-latest]
 
     container:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Version 2.0.0
+* renamed `argparse` module to `args`, to avoid name clash with OTP 26
+
 ### Version 1.2.4:
 * minor spec fixes
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # argparse: command line parser for Erlang
 
+> **Warning**
+> This project is no longer maintained, because argparse is now a part of
+> Erlang/OTP: https://www.erlang.org/doc/man/argparse.html (starting with OTP 26).
+> If you need code in `cli.erl`, feel free to copy and paste it directly in your project.
+
+
 [![Build Status](https://github.com/max-au/argparse/actions/workflows/erlang.yml/badge.svg?branch=master)](https://github.com/max-au/argparse/actions) [![Hex.pm](https://img.shields.io/hexpm/v/argparse.svg)](https://hex.pm/packages/argparse) [![Hex Docs](https://img.shields.io/badge/hex-docs-blue.svg)](https://hexdocs.pm/argparse)
 
 A mini-framework to create complex cli. Inspired by Python argparse.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 > This project is no longer maintained, because argparse is now a part of
 > Erlang/OTP: https://www.erlang.org/doc/man/argparse.html (starting with OTP 26).
 > If you need code in `cli.erl`, feel free to copy and paste it directly in your project.
+>
+> To accommodate with this change, `argparse` module has been renamed to `args`
+> in version 2.0.0. Applications that need `argparse` for earlier OTP versions
+> can use this library until the lowest supported version is OTP 26, and then
+> just move forward to `argparse` provided by OTP.
+>
+> There are minor differences in the command line options description between
+> `args` and OTP `argparse`.
 
 
 [![Build Status](https://github.com/max-au/argparse/actions/workflows/erlang.yml/badge.svg?branch=master)](https://github.com/max-au/argparse/actions) [![Hex.pm](https://img.shields.io/hexpm/v/argparse.svg)](https://hex.pm/packages/argparse) [![Hex Docs](https://img.shields.io/badge/hex-docs-blue.svg)](https://hexdocs.pm/argparse)
@@ -13,7 +21,7 @@ A mini-framework to create complex cli. Inspired by Python argparse.
 Follows conventions of  Unix Utility Argument Syntax.
 
 ```shell
-    argparse [-abcDxyz][-p arg][operand]
+    args [-abcDxyz][-p arg][operand]
 ```
 
 ## Argument parser
@@ -142,7 +150,7 @@ It is possible to use argument parser alone, without the cli mini-framework:
 
     main(Args) ->
         #{force := Force, recursive := Recursive, dir := Dir} =
-            argparse:parse(Args, cli()),
+            args:parse(Args, cli()),
         io:format("Removing ~s (force: ~s, recursive: ~s)~n",
             [Dir, Force, Recursive]).
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Command definitions:
             commands => #{
                 "sum" => #{
                     arguments => [
-                        #{name => num, nargs => nonempty_list, type => int, help => "Numbers to sum"}
+                        #{name => num, nargs => nonempty_list, type => integer, help => "Numbers to sum"}
                     ]
                 },
                 "math" => #{
@@ -88,8 +88,8 @@ Command definitions:
                 },
                 "mul" => #{
                     arguments => [
-                        #{name => left, type => int},
-                        #{name => right, type => int}
+                        #{name => left, type => integer},
+                        #{name => right, type => integer}
                     ]
                 }
             }

--- a/doc/examples/escript/erm
+++ b/doc/examples/escript/erm
@@ -5,10 +5,7 @@
 %%  ERL_FLAGS="-pa ../../../_build/default/lib/argparse/ebin" ./erm -rf dir
 
 main(Args) ->
-    #{force := Force, recursive := Recursive, dir := Dir} =
-        argparse:parse(Args, cli()),
-    io:format("Removing ~s (force: ~s, recursive: ~s)~n",
-        [Dir, Force, Recursive]).
+    io:format("~ts~n", [argparse:help(cli())]).
 
 %% parser specification
 cli() ->

--- a/src/argparse.app.src
+++ b/src/argparse.app.src
@@ -1,6 +1,6 @@
 {application, argparse,
  [{description, "argparse: arguments parser, and cli framework"},
-  {vsn, "1.2.4"},
+  {vsn, "2.0.0"},
   {applications,
    [kernel,
     stdlib

--- a/src/argparse.erl
+++ b/src/argparse.erl
@@ -1,117 +1,92 @@
-%%%-------------------------------------------------------------------
-%%% @author Maxim Fedorov, <maximfca@gmail.com>
-%%% @doc
-%%% Command line parser, made with hierarchy of commands in mind.
-%%% Parser operates with <em>arguments</em> and <em>commands</em>, organised in a hierarchy. It is possible
-%%% to define multiple commands, or none. Parsing always starts with root <em>command</em>,
-%%% named after `init:get_argument(progname)'. Empty command produces empty argument map:
-%%% ```
-%%% 1> parse("", #{}).
-%%%    #{}
-%%% '''
-%%%
-%%%
-%%% If root level command does not contain any sub-commands, parser returns plain map of
-%%% argument names to their values:
-%%% ```
-%%% 3> argparse:parse(["value"], #{arguments => [#{name => arg}]}).
-%%% #{arg => "value"}
-%%% '''
-%%% This map contains all arguments matching command line passed, initialised with
-%%% corresponding values. If argument is omitted, but default value is specified for it,
-%%% it is added to the map. When no default value specified, and argument is not
-%%% present, corresponding key is not present in the map.
-%%%
-%%% Missing required (field <strong>required</strong> is set to true for optional arguments,
-%%% or missing for positional) arguments raises an error.
-%%%
-%%% When there are sub-commands, parser returns argument map, deepest matched command
-%%% name, and a sub-spec passed for this command:
-%%% ```
-%%% 4> Cmd =  #{arguments => [#{name => arg}]}.
-%%% #{arguments => [#{name => arg}]}
-%%% 5> argparse:parse(["cmd", "value"], #{commands => #{"cmd" => Cmd}}).
-%%% {#{arg => "value"},{"cmd",#{arguments => [#{name => arg}]}}}
-%%% '''
-%%% @end
+%%
+%%
+%% Copyright Maxim Fedorov
+%%
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
 
 -module(argparse).
 -author("maximfca@gmail.com").
 
+%% API Exports
 -export([
-    validate/1,
-    validate/2,
-    parse/2,
-    parse/3,
-    help/1,
-    help/2,
-    format_error/1,
-    format_error/3
+    run/3,
+    parse/2, parse/3,
+    help/1, help/2,
+    format_error/1
 ]).
+
+%% Internal exports for validation and error reporting.
+-export([validate/1, validate/2, format_error/2]).
 
 %%--------------------------------------------------------------------
 %% API
 
--compile(warn_missing_spec).
-
-%% @doc
-%% Built-in types include basic validation abilities
-%% String and binary validation may use regex match (ignoring captured value).
-%% For float, int, string, binary and atom type, it is possible to specify
-%%  available choices instead of regex/min/max.
-%% @end
 -type arg_type() ::
     boolean |
     float |
-    {float, [float()]} |
+    {float, Choice :: [float()]} |
     {float, [{min, float()} | {max, float()}]} |
-    int |
-    {int, [integer()]} |
-    {int, [{min, integer()} | {max, integer()}]} |
+    integer |
+    {integer, Choices :: [integer()]} |
+    {integer, [{min, integer()} | {max, integer()}]} |
     string |
-    {string, [string()]} |
-    {string, string()} |
-    {string, string(), [term()]} |
+    {string, Choices :: [string()]} |
+    {string, Re :: string()} |
+    {string, Re :: string(), ReOptions :: [term()]} |
     binary |
-    {binary, [binary()]} |
-    {binary, binary()} |
-    {binary, binary(), [term()]} |
+    {binary, Choices :: [binary()]} |
+    {binary, Re :: binary()} |
+    {binary, Re :: binary(), ReOptions :: [term()]} |
     atom |
-    {atom, [atom()]} |
+    {atom, Choices :: [atom()]} |
     {atom, unsafe} |
     {custom, fun((string()) -> term())}.
+%% Built-in types include basic validation abilities
+%% String and binary validation may use regex match (ignoring captured value).
+%% For float, integer, string, binary and atom type, it is possible to specify
+%%  available choices instead of regex/min/max.
 
+-type argument_help() :: {
+    unicode:chardata(), %% short form, printed in command usage, e.g. "[--dir <dirname>]", developer is
+                        %% responsible for proper formatting (e.g. adding <>, dots... and so on)
+    [unicode:chardata() | type | default] | fun(() -> unicode:chardata())
+}.
 %% Help template definition for argument. Short and long forms exist for every argument.
 %% Short form is printed together with command definition, e.g. "usage: rm [--force]",
 %%  while long description is printed in detailed section below: "--force   forcefully remove".
--type argument_help() :: {
-    string(), %% short form, printed in command usage, e.g. "[--dir <dirname>]", developer is
-              %%    responsible for proper formatting (e.g. adding <>, dots... and so on)
-    [string() | type | default]  %% long description, default is [help, " (", type, ", ", default, ")"] -
-                                 %%    "floating-point long form argument, float, [3.14]"
-}.
 
-%% Command line argument specification.
-%% Argument can be optional - starting with - (dash), and positional.
+-type argument_name() :: atom() | string() | binary().
+
 -type argument() :: #{
     %% Argument name, and a destination to store value too
     %% It is allowed to have several arguments named the same, setting or appending to the same variable.
-    %% It is used to format the name, hence it should be format-table with "~ts".
-    name := atom() | string() | binary(),
+    name := argument_name(),
 
     %% short, single-character variant of command line option, omitting dash (example: $b, meaning -b),
-    %%  when present, this is optional argument
+    %%  when present, the argument is considered optional
     short => char(),
 
-    %% long command line option, omitting first dash (example: "kernel", or "-long", meaning "-kernel" and "--long"
+    %% long command line option, omitting first dash (example: "kernel" means "-kernel" in the command line)
     %% long command always wins over short abbreviation (e.g. -kernel is considered before -k -e -r -n -e -l)
-    %%  when present, this is optional argument
+    %%  when present, the argument is considered optional
     long => string(),
 
-    %% throws an error if value is not present in command line
+    %% makes parser to return an error if the argument is not present in the command line
     required => boolean(),
 
-    %% default value, produced if value is not present in command line
+    %% default value, produced if the argument is not present in the command line
+    %% parser also accepts a global default
     default => term(),
 
     %% parameter type (string by default)
@@ -129,87 +104,198 @@
     nargs =>
         pos_integer() |     %% consume exactly this amount, e.g. '-kernel key value' #{long => "-kernel", args => 2}
                             %%      returns #{kernel => ["key", "value"]}
-        'maybe' |           %% if next argument is positional, consume it, otherwise produce default
-        {'maybe', term()} | %% if next argument is positional, consume it, otherwise produce term()
+        'maybe' |           %% if the next argument is positional, consume it, otherwise produce default
+        {'maybe', term()} | %% if the next argument is positional, consume it, otherwise produce term()
         list |              %% consume zero or more positional arguments, until next optional
         nonempty_list |     %% consume at least one positional argument, until next optional
         all,                %% fold remaining command line into this argument
 
     %% help string printed in usage, hidden help is not printed at all
-    help => hidden | string() | argument_help()
+    help => hidden | unicode:chardata() | argument_help()
 }.
+%% Command line argument specification.
+%% Argument can be optional - starting with - (dash), and positional.
 
--type arg_map() :: #{term() => term()}. %% Arguments map: argument name to a term, produced by parser. Supplied to command handler
+-type arg_map() :: #{argument_name() => term()}.
+%% Arguments map: argument name to a term, produced by parser. Supplied to the command handler
 
+-type handler() ::
+    optional |                      %% valid for commands with sub-commands, suppresses parser error when no
+                                    %%   sub-command is selected
+    fun((arg_map()) -> term()) |    %% handler accepting arg_map
+    {module(), Fn :: atom()} |      %% handler, accepting arg_map, Fn exported from module()
+    {fun(() -> term()), term()} |   %% handler, positional form (term() is supplied for omitted args)
+    {module(), atom(), term()}.     %% handler, positional form, exported from module()
 %% Command handler. May produce some output. Can accept a map, or be
 %%  arbitrary mfa() for handlers accepting positional list.
 %% Special value 'optional' may be used to suppress an error that
 %%  otherwise raised when command contains sub-commands, but arguments
 %%  supplied via command line do not select any.
--type handler() ::
-    optional |                          %% valid for commands with sub-commands, suppresses error when no
-                                        %%   sub-command is selected
-    fun((arg_map()) -> term()) |        %% handler accepting arg_map
-    {module(), Fn :: atom()} |          %% handler, accepting arg_map, Fn exported from module()
-    {fun((arg_map()) -> term()), term()} |  %% handler, positional form
-    {module(), atom(), term()}.         %% handler, positional form, exported from module()
 
--type command_map() :: #{string() => command()}. %% Sub-commands are arranged into maps (cannot start with <em>prefix</em>)
-
-%% Command help template, RFC for future implementation
-%% Default is ["usage: ", name, " ", flags, " ", options, " ", arguments, "\n", help, "\n", commands, "\n",
-%%      {arguments, long}, "\n", {options, long}, "\n"]
-%% -type command_help() :: [
-%%     string() |          %% text string, as is
-%%     name |              %% command name (or progname, if it's top-level command)
-%%     flags |             %% flags: [-rfv]
-%%     options |           %% options: [--force] [-i <interval>] [--dir <dir>]
-%%     arguments |         %% <server> [<optpos>]
-%%     commands |          %%   status      prints server status
-%%     {arguments, long} | %%   server       server to start
-%%     {options, long}     %%   -f, --force force
-%% ].
+-type command_help() :: [unicode:chardata() | usage | commands | arguments | options].
+%% Template for the command help/usage message.
 
 %% Command descriptor
 -type command() :: #{
-    %% Sub-commands
-    commands => command_map(),
-
-    %% accepted arguments list. Positional order is important!
+    %% Sub-commands are arranged into maps. Command name must not start with <em>prefix</em>.
+    commands => #{string() => command()},
+    %% accepted arguments list. Order is important!
     arguments => [argument()],
-
     %% help line
-    help => hidden | string(),
-
-    %% recommended handler function, cli behaviour deduces handler from
-    %%  command name and module implementing cli behaviour
+    help => hidden | unicode:chardata() | command_help(),
+    %% recommended handler function
     handler => handler()
 }.
 
--export_type([
-    argument/0,
-    command/0,
-    handler/0,
-    cmd_path/0,
-    arg_map/0
-]).
+-type cmd_path() :: [string()].
+%% Command path, for nested commands
 
-%% Optional or positional argument?
--define(IS_OPTIONAL(Arg), is_map_key(short, Arg) orelse is_map_key(long, Arg)).
+-export_type([arg_type/0, argument_help/0, argument/0,
+    command/0, handler/0, cmd_path/0, arg_map/0]).
 
--type cmd_path() :: [string()]. %% Command path, for deeply nested sub-commands
+-type parser_error() :: {Path :: cmd_path(),
+    Expected :: argument() | undefined,
+    Actual :: string() | undefined,
+    Details :: unicode:chardata()}.
+%% Returned from `parse/2,3' when command spec is valid, but the command line
+%% cannot be parsed using the spec.
+%% When `Expected' is undefined, but `Actual' is not, it means that the input contains
+%% an unexpected argument which cannot be parsed according to command spec.
+%% When `Expected' is an argument, and `Actual' is undefined, it means that a mandatory
+%% argument is not provided in the command line.
+%% When both `Expected' and `Actual' are defined, it means that the supplied argument
+%% is failing validation.
+%% When both are `undefined', there is some logical issue (e.g. a sub-command is required,
+%% but was not selected).
+
+-type parser_options() :: #{
+    %% allowed prefixes (default is [$-]).
+    prefixes => [char()],
+    %% default value for all missing optional arguments
+    default => term(),
+    %% root command name (program name)
+    progname => string() | atom(),
+    %% considered by `help/2' only
+    command => cmd_path(),      %% command to print the help for
+    columns => pos_integer()    %% viewport width, in characters
+}.
+%% Parser options
+
+-type parse_result() ::
+    {ok, arg_map(), Path :: cmd_path(), command()} |
+    {error, parser_error()}.
+%% Parser result: argument map, path leading to successfully
+%% matching command (contains only ["progname"] if there were
+%% no subcommands matched), and a matching command.
+
+%% @equiv validate(Command, #{})
+-spec validate(command()) -> Progname :: string().
+validate(Command) ->
+    validate(Command, #{}).
+
+%% @doc Validate command specification, taking Options into account.
+%% Raises an error if the command specification is invalid.
+-spec validate(command(), parser_options()) -> Progname :: string().
+validate(Command, Options) ->
+    Prog = executable(Options),
+    is_list(Prog) orelse erlang:error(badarg, [Command, Options],
+        [{error_info, #{cause => #{2 => <<"progname is not valid">>}}}]),
+    Prefixes = maps:from_list([{P, true} || P <- maps:get(prefixes, Options, [$-])]),
+    _ = validate_command([{Prog, Command}], Prefixes),
+    Prog.
+
+%% @equiv parse(Args, Command, #{})
+-spec parse(Args :: [string()], command()) -> parse_result().
+parse(Args, Command) ->
+    parse(Args, Command, #{}).
+
+%% @doc Parses supplied arguments according to expected command specification.
+%% @param Args command line arguments (e.g. `init:get_plain_arguments()')
+%% @returns argument map, or argument map with deepest matched command
+%%  definition.
+-spec parse(Args :: [string()], command(), Options :: parser_options()) -> parse_result().
+parse(Args, Command, Options) ->
+    Prog = validate(Command, Options),
+    %% use maps and not sets v2, because sets:is_element/2 cannot be used in guards (unlike is_map_key)
+    Prefixes = maps:from_list([{P, true} || P <- maps:get(prefixes, Options, [$-])]),
+    try
+        parse_impl(Args, merge_arguments(Prog, Command, init_parser(Prefixes, Command, Options)))
+    catch
+        %% Parser error may happen at any depth, and bubbling the error is really
+        %% cumbersome. Use exceptions and catch it before returning from `parse/2,3' instead.
+        throw:Reason ->
+            {error, Reason}
+    end.
+
+%% @equiv help(Command, #{})
+-spec help(command()) -> string().
+help(Command) ->
+    help(Command, #{}).
+
+%% @doc Returns help for Command formatted according to Options specified
+-spec help(command(), parser_options()) -> unicode:chardata().
+help(Command, Options) ->
+    Prog = validate(Command, Options),
+    format_help({Prog, Command}, Options).
+
+%% @doc
+-spec run(Args :: [string()], command(), parser_options()) -> term().
+run(Args, Command, Options) ->
+    try parse(Args, Command, Options) of
+        {ok, ArgMap, Path, SubCmd} ->
+            handle(Command, ArgMap, tl(Path), SubCmd);
+        {error, Reason} ->
+            io:format("error: ~ts~n", [argparse:format_error(Reason)]),
+            io:format("~ts", [argparse:help(Command, Options#{command => tl(element(1, Reason))})]),
+            erlang:halt(1)
+    catch
+        error:Reason:Stack ->
+            io:format(erl_error:format_exception(error, Reason, Stack)),
+            erlang:halt(1)
+    end.
+
+%% @doc Basic formatter for the parser error reason.
+-spec format_error(Reason :: parser_error()) -> unicode:chardata().
+format_error({Path, undefined, undefined, Details}) ->
+    io_lib:format("~ts: ~ts", [format_path(Path), Details]);
+format_error({Path, undefined, Actual, Details}) ->
+    io_lib:format("~ts: unknown argument: ~ts~ts", [format_path(Path), Actual, Details]);
+format_error({Path, #{name := Name}, undefined, Details}) ->
+    io_lib:format("~ts: required argument missing: ~ts~ts", [format_path(Path), Name, Details]);
+format_error({Path, #{name := Name}, Value, Details}) ->
+    io_lib:format("~ts: invalid argument for ~ts: ~ts ~ts", [format_path(Path), Name, Value, Details]).
+
+-type validator_error() ::
+    {?MODULE, command | argument, cmd_path(), Field :: atom(), Detail :: unicode:chardata()}.
+
+%% @doc Transforms exception thrown by `validate/1,2' according to EEP54.
+%% Use `erl_error:format_exception/3,4' to get the shell-like output.
+-spec format_error(Reason :: validator_error(), erlang:stacktrace()) -> map().
+format_error({?MODULE, command, Path, Field, Reason}, [{_M, _F, [Cmd], Info} | _]) ->
+    #{cause := Cause} = proplists:get_value(error_info, Info, #{}),
+    Cause#{general => <<"command specification is invalid">>, 1 => io_lib:format("~tp", [Cmd]),
+        reason => io_lib:format("command \"~ts\": invalid field '~ts', reason: ~ts", [format_path(Path), Field, Reason])};
+format_error({?MODULE, argument, Path, Field, Reason}, [{_M, _F, [Arg], Info} | _]) ->
+    #{cause := Cause} = proplists:get_value(error_info, Info, #{}),
+    ArgName = maps:get(name, Arg, ""),
+    Cause#{general => "argument specification is invalid", 1 => io_lib:format("~tp", [Arg]),
+        reason => io_lib:format("command \"~ts\", argument '~ts', invalid field '~ts': ~ts",
+            [format_path(Path), ArgName, Field, Reason])}.
+
+%%--------------------------------------------------------------------
+%% Parser implementation
 
 %% Parser state (not available via API)
 -record(eos, {
     %% prefix character map, by default, only -
-    prefixes :: #{integer() => true},
+    prefixes :: #{char() => true},
     %% argument map to be returned
     argmap = #{} :: arg_map(),
-    %% sub-commands, in reversed orders, allowing to recover path taken
+    %% sub-commands, in reversed orders, allowing to recover the path taken
     commands = [] :: cmd_path(),
     %% command being matched
     current :: command(),
-    %% unmatched positional arguments, in expected match order
+    %% unmatched positional arguments, in the expected match order
     pos = [] :: [argument()],
     %% expected optional arguments, mapping between short/long form and an argument
     short = #{} :: #{integer() => argument()},
@@ -220,107 +306,11 @@
     default :: error | {ok, term()}
 }).
 
-%% Error Reason thrown by parser (feed it into format_error to get human-readable error).
--type argparse_reason() ::
-    {invalid_command, cmd_path(), Field :: atom(), Reason :: string()} |
-    {invalid_option, cmd_path(), Name :: string(), Field :: atom(), Reason :: string()} |
-    {unknown_argument, cmd_path(), Argument :: string()} |
-    {missing_argument, cmd_path(), argument()} |
-    {invalid_argument, cmd_path(), argument(), Argument :: string()}.
+init_parser(Prefixes, Cmd, Options) ->
+    #eos{prefixes = Prefixes, current = Cmd, default = maps:find(default, Options)}.
 
-%% Parser options
--type parser_options() :: #{
-    %% allowed prefixes (default is [$-]).
-    prefixes => [integer()],
-    %% default value for all missing not required arguments
-    default => term(),
-    %% next fields are only considered when printing usage
-    progname => string() | atom(),   %% program name override
-    command => [string()]   %% nested command (missing/empty for top-level command)
-}.
-
--type command_spec() :: {Name :: [string()], command()}. %% Command name with command spec
-
--type parse_result() :: arg_map() | {arg_map(), command_spec()}. %% Result returned from parse/2,3: can be only argument map,  or argument map with command_spec.
-
-%% @equiv validate(Command, #{})
--spec validate(command()) -> {Progname :: string(), command()}.
-validate(Command) ->
-    validate(Command, #{}).
-
-%% @doc Validate command specification, taking Options into account.
-%% Generates error signal when command specification is invalid.
--spec validate(command(), parser_options()) -> {Progname :: string(), command()}.
-validate(Command, Options) ->
-    validate_impl(Command, Options).
-
-
-%% @equiv parse(Args, Command, #{})
--spec parse(Args :: [string()], command() | command_spec()) -> parse_result().
-parse(Args, Command) ->
-    parse(Args, Command, #{}).
-
-%% @doc Parses supplied arguments according to expected command definition.
-%% @param Args command line arguments (e.g. `init:get_plain_arguments()')
-%% @returns argument map, or argument map with deepest matched command
-%%  definition.
--spec parse(Args :: [string()], command() | command_spec(),
-    Options :: parser_options()) -> parse_result().
-parse(Args, Command, Options) ->
-    {Prog, Cmd} = validate(Command, Options),
-    Prefixes = maps:from_list([{P, true} || P <- maps:get(prefixes, Options, [$-])]),
-    parse_impl(Args, merge_arguments(Prog, Cmd, #eos{prefixes = Prefixes, current = Cmd,
-        default = maps:find(default, Options)})).
-
-%% By default, options are indented with 2 spaces for each level of
-%%  sub-command.
--define (DEFAULT_INDENT, "  ").
-
-%% @equiv help(Command, #{})
--spec help(command() | command_spec()) -> string().
-help(Command) ->
-    help(Command, #{}).
-
-%% @doc
-%% Returns help for Command formatted according to Options specified
--spec help(command() | command_spec(), parser_options()) -> string().
-help(Command, Options) ->
-    unicode:characters_to_list(format_help(validate(Command, Options), Options)).
-
-%% @doc Format exception reasons produced by parse/2.
-%% Exception of class error with reason {argparse, Reason} is normally
-%%  raised, and format_error accepts only the Reason part, leaving
-%%  other exceptions that do not belong to argparse out.
-%% @returns string, ready to be printed via io:format().
--spec format_error(Reason :: argparse_reason()) -> string().
-format_error({invalid_command, Path, Field, Text}) ->
-    unicode:characters_to_list(io_lib:format("~tsinternal error, invalid field '~ts': ~ts~n",
-        [format_path(Path), Field, Text]));
-format_error({invalid_option, Path, Name, Field, Text}) ->
-    unicode:characters_to_list(io_lib:format("~tsinternal error, option ~ts field '~ts': ~ts~n",
-        [format_path(Path), Name, Field, Text]));
-format_error({unknown_argument, Path, Argument}) ->
-    unicode:characters_to_list(io_lib:format("~tsunrecognised argument: ~ts~n",
-        [format_path(Path), Argument]));
-format_error({missing_argument, Path, Name}) ->
-    unicode:characters_to_list(io_lib:format("~tsrequired argument missing: ~ts~n",
-        [format_path(Path), Name]));
-format_error({invalid_argument, Path, Name, Value}) ->
-    unicode:characters_to_list(io_lib:format("~tsinvalid argument ~ts for: ~ts~n",
-        [format_path(Path), Value, Name])).
-
-%% @doc Formats exception, and adds command usage information for
-%%  command that was known/parsed when exception was raised.
-%% @returns string, ready to be printed via io:format().
--spec format_error(argparse_reason(), command() | command_spec(), parser_options()) -> string().
-format_error(Reason, Command, Options) ->
-    Path = tl(element(2, Reason)),
-    ErrorText = format_error(Reason),
-    UsageText = help(Command, Options#{command => Path}),
-    ErrorText ++ UsageText.
-
-%%--------------------------------------------------------------------
-%% Parser implementation
+%% Optional or positional argument?
+-define(IS_OPTION(Arg), is_map_key(short, Arg) orelse is_map_key(long, Arg)).
 
 %% helper function to match either a long form of "--arg=value", or just "--arg"
 match_long(Arg, LongOpts) ->
@@ -407,21 +397,17 @@ parse_impl([], #eos{argmap = ArgMap0, commands = Commands, current = Current, po
     %% error if stopped at sub-command with no handler
     map_size(maps:get(commands, Current, #{})) >0 andalso
         (not is_map_key(handler, Current)) andalso
-        fail({missing_argument, Commands, "missing handler"}),
+        throw({Commands, undefined, undefined, <<"subcommand expected">>}),
+
     %% go over remaining positional, verify they are all not required
     ArgMap1 = fold_args_map(Commands, true, ArgMap0, Pos, Def),
     %% go over optionals, and either raise an error, or set default
     ArgMap2 = fold_args_map(Commands, false, ArgMap1, maps:values(Eos#eos.short), Def),
     ArgMap3 = fold_args_map(Commands, false, ArgMap2, maps:values(Eos#eos.long), Def),
-    case Eos#eos.commands of
-        [_] ->
-            %% if there were no commands specified, only the argument map
-            ArgMap3;
-        [_|_] ->
-            %% otherwise return argument map, command path taken, and the
-            %%  last command matched (usually it contains a handler to run)
-            {ArgMap3, {tl(lists:reverse(Eos#eos.commands)), Eos#eos.current}}
-    end.
+
+    %% return argument map, command path taken, and the deepest
+    %%  last command matched (usually it contains a handler to run)
+    {ok, ArgMap3, Eos#eos.commands, Eos#eos.current}.
 
 %% Generate error for missing required argument, and supply defaults for
 %%  missing optional arguments that have defaults.
@@ -430,9 +416,9 @@ fold_args_map(Commands, Req, ArgMap, Args, GlobalDefault) ->
         fun (#{name := Name}, Acc) when is_map_key(Name, Acc) ->
                 %% argument present
                 Acc;
-            (#{name := Name, required := true}, _Acc) ->
+            (#{required := true} = Opt, _Acc) ->
                 %% missing, and required explicitly
-                fail({missing_argument, Commands, Name});
+                throw({Commands, Opt, undefined, <<>>});
             (#{name := Name, required := false, default := Default}, Acc) ->
                 %% explicitly not required argument with default
                 Acc#{Name => Default};
@@ -442,9 +428,9 @@ fold_args_map(Commands, Req, ArgMap, Args, GlobalDefault) ->
             (#{name := Name, default := Default}, Acc) when Req =:= true ->
                 %% positional argument with default
                 Acc#{Name => Default};
-            (#{name := Name}, _Acc) when Req =:= true ->
+            (Opt, _Acc) when Req =:= true ->
                 %% missing, for positional argument, implicitly required
-                fail({missing_argument, Commands, Name});
+                throw({Commands, Opt, undefined, <<>>});
             (#{name := Name, default := Default}, Acc) ->
                 %% missing, optional, and there is a default
                 Acc#{Name => Default};
@@ -470,20 +456,20 @@ catch_all_positional(Tail, #eos{argmap = Args, pos = [#{name := Name, default :=
 %% same as above, but no default specified
 catch_all_positional(Tail, #eos{pos = [#{required := false} | Pos]} = Eos) ->
     catch_all_positional(Tail, Eos#eos{pos = Pos});
-catch_all_positional([Arg | _Tail], Eos) ->
-    fail({unknown_argument, Eos#eos.commands, Arg}).
+catch_all_positional([Arg | _Tail], #eos{commands = Commands}) ->
+    throw({Commands, undefined, Arg, <<>>}).
 
 parse_positional(Arg, _Tail, #eos{pos = [], commands = Commands}) ->
-    fail({unknown_argument, Commands, Arg});
+    throw({Commands, undefined, Arg, <<>>});
 parse_positional(Arg, Tail, #eos{pos = Pos} = Eos) ->
     %% positional argument itself is a value
     consume([Arg | Tail], hd(Pos), Eos).
 
 %% Adds CmdName to path, and includes any arguments found there
 merge_arguments(CmdName, #{arguments := Args} = SubCmd, Eos) ->
-    add_args(Args, Eos#eos{current = SubCmd, commands = [CmdName | Eos#eos.commands]});
+    add_args(Args, Eos#eos{current = SubCmd, commands = Eos#eos.commands ++ [CmdName]});
 merge_arguments(CmdName, SubCmd, Eos) ->
-    Eos#eos{current = SubCmd, commands = [CmdName | Eos#eos.commands]}.
+    Eos#eos{current = SubCmd, commands = Eos#eos.commands ++ [CmdName]}.
 
 %% adds arguments into current set of discovered pos/opts
 add_args([], Eos) ->
@@ -559,7 +545,9 @@ abbreviated([Flag | Tail], Acc, AllShort) ->
 %% consume predefined amount (none of which can be an option?)
 consume(Tail, #{nargs := Count} = Opt, Eos) when is_integer(Count) ->
     {Consumed, Remain} = split_to_option(Tail, Count, Eos, []),
-    length(Consumed) < Count andalso fail({invalid_argument, Eos#eos.commands, maps:get(name, Opt), Tail}),
+    length(Consumed) < Count andalso
+        throw({Eos#eos.commands, Opt, Tail,
+            io_lib:format("expected ~b, found ~b argument(s)", [Count, length(Consumed)])}),
     action(Remain, Consumed, Opt#{type => {list, maps:get(type, Opt, string)}}, Eos);
 
 %% handle 'reminder' by just dumping everything in
@@ -569,7 +557,7 @@ consume(Tail, #{nargs := all} = Opt, Eos) ->
 %% require at least one argument
 consume(Tail, #{nargs := nonempty_list} = Opt, Eos) ->
     {Consumed, Remains} = split_to_option(Tail, -1, Eos, []),
-    Consumed =:= [] andalso fail({invalid_argument, Eos#eos.commands, maps:get(name, Opt), Tail}),
+    Consumed =:= [] andalso throw({Eos#eos.commands, Opt, Tail, <<"expected argument">>}),
     action(Remains, Consumed, Opt#{type => {list, maps:get(type, Opt, string)}}, Eos);
 
 %% consume all until next option
@@ -584,8 +572,8 @@ consume(["true" | Tail], #{type := boolean} = Opt, Eos) ->
 consume(["false" | Tail], #{type := boolean} = Opt, Eos) ->
     action(Tail, false, Opt#{type => raw}, Eos);
 consume(Tail, #{type := boolean} = Opt, Eos) ->
-    %% if neither true or false, don't consume, just do the action with 'true' as arg
-    action(Tail, true, Opt#{type => raw}, Eos);
+    %% neither true nor false means 'undefined' (with the default for boolean being true)
+    action(Tail, undefined, Opt, Eos);
 
 %% maybe behaviour, as '?'
 consume(Tail, #{nargs := 'maybe'} = Opt, Eos) ->
@@ -616,12 +604,12 @@ consume(Tail, #{action := {Act, _Const}} = Opt, Eos) when Act =:= store; Act =:=
     action(Tail, undefined, Opt, Eos);
 
 %% optional: ensure not to consume another option start
-consume([[Prefix | _] = ArgValue | Tail], Opt, Eos) when ?IS_OPTIONAL(Opt), is_map_key(Prefix, Eos#eos.prefixes) ->
+consume([[Prefix | _] = ArgValue | Tail], Opt, Eos) when ?IS_OPTION(Opt), is_map_key(Prefix, Eos#eos.prefixes) ->
     case Eos#eos.no_digits andalso is_digits(ArgValue) of
         true ->
             action(Tail, ArgValue, Opt, Eos);
         false ->
-            fail({missing_argument, Eos#eos.commands, maps:get(name, Opt)})
+            throw({Eos#eos.commands, Opt, undefined, <<"expected argument">>})
     end;
 
 consume([ArgValue | Tail], Opt, Eos) ->
@@ -630,7 +618,7 @@ consume([ArgValue | Tail], Opt, Eos) ->
 %% we can only be here if it's optional argument, but there is no value supplied,
 %%  and type is not 'boolean' - this is an error!
 consume([], Opt, Eos) ->
-    fail({missing_argument, Eos#eos.commands, maps:get(name, Opt)}).
+    throw({Eos#eos.commands, Opt, undefined, <<"expected argument">>}).
 
 %% no more arguments for consumption, but last optional may still be action-ed
 %%consume([], Current, Opt, Eos) ->
@@ -660,33 +648,34 @@ split_to_option([Head | Tail], Left, Opts, Acc) ->
 %% Action handling
 
 action(Tail, ArgValue, #{name := ArgName, action := store} = Opt, #eos{argmap = ArgMap} = Eos) ->
-    Value = convert_type(maps:get(type, Opt, string), ArgValue, ArgName, Eos),
+    Value = convert_type(maps:get(type, Opt, string), ArgValue, Opt, Eos),
     continue_parser(Tail,  Opt, Eos#eos{argmap = ArgMap#{ArgName => Value}});
 
 action(Tail, undefined, #{name := ArgName, action := {store, Value}} = Opt, #eos{argmap = ArgMap} = Eos) ->
     continue_parser(Tail,  Opt, Eos#eos{argmap = ArgMap#{ArgName => Value}});
 
 action(Tail, ArgValue, #{name := ArgName, action := append} = Opt, #eos{argmap = ArgMap} = Eos) ->
-    Value = convert_type(maps:get(type, Opt, string), ArgValue, ArgName, Eos),
+    Value = convert_type(maps:get(type, Opt, string), ArgValue, Opt, Eos),
     continue_parser(Tail,  Opt, Eos#eos{argmap = ArgMap#{ArgName => maps:get(ArgName, ArgMap, []) ++ [Value]}});
 
 action(Tail, undefined, #{name := ArgName, action := {append, Value}} = Opt, #eos{argmap = ArgMap} = Eos) ->
     continue_parser(Tail,  Opt, Eos#eos{argmap = ArgMap#{ArgName => maps:get(ArgName, ArgMap, []) ++ [Value]}});
 
 action(Tail, ArgValue, #{name := ArgName, action := extend} = Opt, #eos{argmap = ArgMap} = Eos) ->
-    Value = convert_type(maps:get(type, Opt, string), ArgValue, ArgName, Eos),
+    Value = convert_type(maps:get(type, Opt, string), ArgValue, Opt, Eos),
     Extended = maps:get(ArgName, ArgMap, []) ++ Value,
     continue_parser(Tail, Opt, Eos#eos{argmap = ArgMap#{ArgName => Extended}});
 
 action(Tail, _, #{name := ArgName, action := count} = Opt, #eos{argmap = ArgMap} = Eos) ->
     continue_parser(Tail,  Opt, Eos#eos{argmap = ArgMap#{ArgName => maps:get(ArgName, ArgMap, 0) + 1}});
 
-%% default: same as set
-action(Tail, ArgValue, Opt, Eos) ->
-    action(Tail, ArgValue, Opt#{action => store}, Eos).
+%% default action is `store' (important to sync the code with the first clause above)
+action(Tail, ArgValue, #{name := ArgName} = Opt, #eos{argmap = ArgMap} = Eos) ->
+    Value = convert_type(maps:get(type, Opt, string), ArgValue, Opt, Eos),
+    continue_parser(Tail,  Opt, Eos#eos{argmap = ArgMap#{ArgName => Value}}).
 
 %% pop last positional, unless nargs is list/nonempty_list
-continue_parser(Tail, Opt, Eos) when ?IS_OPTIONAL(Opt) ->
+continue_parser(Tail, Opt, Eos) when ?IS_OPTION(Opt) ->
     parse_impl(Tail, Eos);
 continue_parser(Tail, #{nargs := List}, Eos) when List =:= list; List =:= nonempty_list ->
     parse_impl(Tail, Eos);
@@ -709,94 +698,96 @@ convert_type(string, Arg, _Opt, _Eos) ->
     Arg;
 convert_type({string, Choices}, Arg, Opt, Eos) when is_list(Choices), is_list(hd(Choices)) ->
     lists:member(Arg, Choices) orelse
-        fail({invalid_argument, Eos#eos.commands, Opt, Arg}),
+        throw({Eos#eos.commands, Opt, Arg, <<"is not one of the choices">>}),
     Arg;
 convert_type({string, Re}, Arg, Opt, Eos) ->
     case re:run(Arg, Re) of
         {match, _X} -> Arg;
-        _ -> fail({invalid_argument, Eos#eos.commands, Opt, Arg})
+        _ -> throw({Eos#eos.commands, Opt, Arg, <<"does not match">>})
     end;
 convert_type({string, Re, ReOpt}, Arg, Opt, Eos) ->
     case re:run(Arg, Re, ReOpt) of
         match -> Arg;
         {match, _} -> Arg;
-        _ -> fail({invalid_argument, Eos#eos.commands, Opt, Arg})
+        _ -> throw({Eos#eos.commands, Opt, Arg, <<"does not match">>})
     end;
-convert_type(int, Arg, Opt, Eos) ->
+convert_type(integer, Arg, Opt, Eos) ->
     get_int(Arg, Opt, Eos);
-convert_type({int, Opts}, Arg, Opt, Eos) ->
-    minimax(get_int(Arg, Opt, Eos), Opts, Eos, Opt);
+convert_type({integer, Opts}, Arg, Opt, Eos) ->
+    minimax(get_int(Arg, Opt, Eos), Opts, Eos, Opt, Arg);
 convert_type(boolean, "true", _Opt, _Eos) ->
+    true;
+convert_type(boolean, undefined, _Opt, _Eos) ->
     true;
 convert_type(boolean, "false", _Opt, _Eos) ->
     false;
 convert_type(boolean, Arg, Opt, Eos) ->
-    fail({invalid_argument, Eos#eos.commands, Opt, Arg});
+    throw({Eos#eos.commands, Opt, Arg, <<"is not a boolean">>});
 convert_type(binary, Arg, _Opt, _Eos) ->
     unicode:characters_to_binary(Arg);
 convert_type({binary, Choices}, Arg, Opt, Eos) when is_list(Choices), is_binary(hd(Choices)) ->
     Conv = unicode:characters_to_binary(Arg),
     lists:member(Conv, Choices) orelse
-        fail({invalid_argument, Eos#eos.commands, Opt, Arg}),
+        throw({Eos#eos.commands, Opt, Arg, <<"is not one of the choices">>}),
     Conv;
 convert_type({binary, Re}, Arg, Opt, Eos) ->
     case re:run(Arg, Re) of
         {match, _X} -> unicode:characters_to_binary(Arg);
-        _ -> fail({invalid_argument, Eos#eos.commands, Opt, Arg})
+        _ -> throw({Eos#eos.commands, Opt, Arg, <<"does not match">>})
     end;
 convert_type({binary, Re, ReOpt}, Arg, Opt, Eos) ->
     case re:run(Arg, Re, ReOpt) of
         match -> unicode:characters_to_binary(Arg);
         {match, _} -> unicode:characters_to_binary(Arg);
-        _ -> fail({invalid_argument, Eos#eos.commands, Opt, Arg})
+        _ -> throw({Eos#eos.commands, Opt, Arg, <<"does not match">>})
     end;
 convert_type(float, Arg, Opt, Eos) ->
     get_float(Arg, Opt, Eos);
 convert_type({float, Opts}, Arg, Opt, Eos) ->
-    minimax(get_float(Arg, Opt, Eos), Opts, Eos, Opt);
+    minimax(get_float(Arg, Opt, Eos), Opts, Eos, Opt, Arg);
 convert_type(atom, Arg, Opt, Eos) ->
     try list_to_existing_atom(Arg)
     catch error:badarg ->
-        fail({invalid_argument, Eos#eos.commands, Opt, Arg})
+        throw({Eos#eos.commands, Opt, Arg, <<"is not an existing atom">>})
     end;
 convert_type({atom, unsafe}, Arg, _Opt, _Eos) ->
     list_to_atom(Arg);
 convert_type({atom, Choices}, Arg, Opt, Eos) ->
     try
         Atom = list_to_existing_atom(Arg),
-        lists:member(Atom, Choices) orelse fail({invalid_argument, Eos#eos.commands, Opt, Arg}),
+        lists:member(Atom, Choices) orelse throw({Eos#eos.commands, Opt, Arg, <<"is not one of the choices">>}),
         Atom
     catch error:badarg ->
-        fail({invalid_argument, Eos#eos.commands, Opt, Arg})
+        throw({Eos#eos.commands, Opt, Arg, <<"is not an existing atom">>})
     end;
 convert_type({custom, Fun}, Arg, Opt, Eos) ->
     try Fun(Arg)
-    catch error:invalid_argument ->
-        fail({invalid_argument, Eos#eos.commands, Opt, Arg})
+    catch error:badarg ->
+        throw({Eos#eos.commands, Opt, Arg, <<"failed faildation">>})
     end.
 
 %% Given Var, and list of {min, X}, {max, Y}, ensure that
 %%  value falls within defined limits.
-minimax(Var, [], _Eos, _Opt) ->
+minimax(Var, [], _Eos, _Opt, _Orig) ->
     Var;
-minimax(Var, [{min, Min} | _], Eos, Opt) when Var < Min ->
-    fail({invalid_argument, Eos#eos.commands, Opt, Var});
-minimax(Var, [{max, Max} | _], Eos, Opt) when Var > Max ->
-    fail({invalid_argument, Eos#eos.commands, Opt, Var});
-minimax(Var, [Num | Tail], Eos, Opt) when is_number(Num) ->
+minimax(Var, [{min, Min} | _], Eos, Opt, Orig) when Var < Min ->
+    throw({Eos#eos.commands, Opt, Orig, <<"is less than accepted minimum">>});
+minimax(Var, [{max, Max} | _], Eos, Opt, Orig) when Var > Max ->
+    throw({Eos#eos.commands, Opt, Orig, <<"is greater than accepted maximum">>});
+minimax(Var, [Num | Tail], Eos, Opt, Orig) when is_number(Num) ->
     lists:member(Var, [Num|Tail]) orelse
-        fail({invalid_argument, Eos#eos.commands, Opt, Var}),
+        throw({Eos#eos.commands, Opt, Orig, <<"is not one of the choices">>}),
     Var;
-minimax(Var, [_ | Tail], Eos, Opt) ->
-    minimax(Var, Tail, Eos, Opt).
+minimax(Var, [_ | Tail], Eos, Opt, Orig) ->
+    minimax(Var, Tail, Eos, Opt, Orig).
 
-%% returns int from string, or errors out with debugging info
+%% returns integer from string, or errors out with debugging info
 get_int(Arg, Opt, Eos) ->
     case string:to_integer(Arg) of
         {Int, []} ->
             Int;
         _ ->
-            fail({invalid_argument, Eos#eos.commands, Opt, Arg})
+            throw({Eos#eos.commands, Opt, Arg, <<"is not an integer">>})
     end.
 
 %% returns float from string, that is floating-point, or integer
@@ -810,7 +801,7 @@ get_float(Arg, Opt, Eos) ->
                 {Int, []} ->
                     Int;
                 _ ->
-                    fail({invalid_argument, Eos#eos.commands, Opt, Arg})
+                    throw({Eos#eos.commands, Opt, Arg, <<"is not a number">>})
             end
     end.
 
@@ -834,7 +825,7 @@ default(#{default := Default}) ->
     Default;
 default(#{type := boolean}) ->
     true;
-default(#{type := int}) ->
+default(#{type := integer}) ->
     0;
 default(#{type := float}) ->
     0.0;
@@ -850,12 +841,7 @@ default(_) ->
 
 %% command path is now in direct order
 format_path(Commands) ->
-    lists:concat(lists:join(" ", Commands)) ++ ": ".
-
-%% to simplify throwing errors with the right reason
-fail(Reason) ->
-    FixedPath = lists:reverse(element(2, Reason)),
-    erlang:error({?MODULE, setelement(2, Reason, FixedPath)}).
+    lists:join(" ", Commands).
 
 %%--------------------------------------------------------------------
 %% Validation and preprocessing
@@ -864,43 +850,48 @@ fail(Reason) ->
 %%  trying to understand why things don't work, that is makes sense
 %%  to provide a mini-Dialyzer here.
 
-validate_impl(Command, #{progname := Prog} = Options) when is_list(Prog) ->
-    Prefixes = maps:from_list([{P, true} || P <- maps:get(prefixes, Options, [$-])]),
-    validate_command([{Prog, Command}], Prefixes);
-validate_impl(Command, #{progname := Prog} = Options) when is_atom(Prog) ->
-    Prefixes = maps:from_list([{P, true} || P <- maps:get(prefixes, Options, [$-])]),
-    validate_command([{atom_to_list(Prog), Command}], Prefixes);
-validate_impl(_Command, #{progname := _Prog} = _Options) ->
-    fail({invalid_command, [], progname, "progname must be a list or an atom"});
-validate_impl(Command, Options) ->
-    {ok, [[Prog]]} = init:get_argument(progname),
-    validate_impl(Command, Options#{progname => Prog}).
+%% to simplify throwing errors with the right reason
+-define (INVALID(Kind, Entity, Path, Field, Text),
+    erlang:error({?MODULE, Kind, clean_path(Path), Field, Text}, [Entity], [{error_info, #{cause => #{}}}])).
 
-%% validates commands, throws invalid_command or invalid_option error
+executable(#{progname := Prog}) when is_atom(Prog) ->
+    atom_to_list(Prog);
+executable(#{progname := Prog}) when is_binary(Prog) ->
+    binary_to_list(Prog);
+executable(#{progname := Prog}) ->
+    Prog;
+executable(_) ->
+    {ok, [[Prog]]} = init:get_argument(progname),
+    Prog.
+
+%% Recursive command validator
 validate_command([{Name, Cmd} | _] = Path, Prefixes) ->
     (is_list(Name) andalso (not is_map_key(hd(Name), Prefixes))) orelse
-        fail({invalid_command, clean_path(Path), commands, "command name must be a string, not starting with optional prefix"}),
+        ?INVALID(command, Cmd, tl(Path), commands,
+            <<"command name must be a string not starting with option prefix">>),
     is_map(Cmd) orelse
-        fail({invalid_command, clean_path(Path), commands, "command description must be a map"}),
-    is_list(maps:get(help, Cmd, [])) orelse (maps:get(help, Cmd) =:= hidden) orelse
-        fail({invalid_command, clean_path(Path), help, "help must be a string"}),
+        ?INVALID(command, Cmd, Path, commands, <<"expected command()">>),
+    (maps:find(help, Cmd) =:= {ok, hidden}) orelse (io_lib:printable_unicode_list(maps:get(help, Cmd, []))) orelse
+        (is_list(maps:get(help, Cmd, [])) andalso lists:all(
+            fun (Atom) when Atom =:= usage; Atom =:= commands; Atom =:= arguments; Atom =:= options -> true;
+                (Str) -> io_lib:printable_unicode_list(Str) end, maps:get(help, Cmd, []))) orelse
+        ?INVALID(command, Cmd, Path, help, <<"must be a printable unicode list, or a command help template">>),
     is_map(maps:get(commands, Cmd, #{})) orelse
-        fail({invalid_command, clean_path(Path), commands, "sub-commands must be a map"}),
+        ?INVALID(command, Cmd, Path, commands, <<"expected map of #{string() => command()}">>),
     case maps:get(handler, Cmd, optional) of
         optional -> ok;
         {Mod, ModFun} when is_atom(Mod), is_atom(ModFun) -> ok; %% map form
         {Mod, ModFun, _} when is_atom(Mod), is_atom(ModFun) -> ok; %% positional form
         {Fun, _} when is_function(Fun) -> ok; %% positional form
         Fun when is_function(Fun, 1) -> ok;
-        _ -> fail({invalid_command, clean_path(Path), handler,
-            "handler must be a fun(ArgMap), {Mod, Fun}, {fun(...), Default}, {Mod, Fun, Default} or 'optional'"})
+        _ -> ?INVALID(command, Cmd, Path, handler, <<"handler must be a valid callback, or an atom 'optional'">>)
     end,
     Cmd1 =
         case maps:find(arguments, Cmd) of
             error ->
                 Cmd;
             {ok, Opts} when not is_list(Opts) ->
-                fail({invalid_command, clean_path(Path), commands, "options must be a list"});
+                ?INVALID(command, Cmd, Path, arguments, <<"expected a list, [argument()]">>);
             {ok, Opts} ->
                 Cmd#{arguments => [validate_option(Path, Opt) || Opt <- Opts]}
         end,
@@ -908,15 +899,17 @@ validate_command([{Name, Cmd} | _] = Path, Prefixes) ->
     lists:foldl(
         fun ({_, #{arguments := Opts}}, Acc) ->
             lists:foldl(
-                fun (#{short := Short, name := OName}, {AllS, AllL}) ->
+                fun (#{short := Short, name := OName} = Arg, {AllS, AllL}) ->
                         is_map_key(Short, AllS) andalso
-                            fail({invalid_option, clean_path(Path), OName, short,
-                                "short conflicting with " ++ atom_to_list(maps:get(Short, AllS))}),
+                            ?INVALID(argument, Arg, Path, short,
+                                "short conflicting with previously defined short for "
+                                    ++ atom_to_list(maps:get(Short, AllS))),
                         {AllS#{Short => OName}, AllL};
-                    (#{long := Long, name := OName}, {AllS, AllL}) ->
+                    (#{long := Long, name := OName} = Arg, {AllS, AllL}) ->
                         is_map_key(Long, AllL) andalso
-                            fail({invalid_option, clean_path(Path), OName, long,
-                                    "long conflicting with " ++ atom_to_list(maps:get(Long, AllL))}),
+                            ?INVALID(argument, Arg, Path, long,
+                                "long conflicting with previously defined long for "
+                                    ++ atom_to_list(maps:get(Long, AllL))),
                         {AllS, AllL#{Long => OName}};
                     (_, AccIn) ->
                         AccIn
@@ -937,25 +930,22 @@ validate_command([{Name, Cmd} | _] = Path, Prefixes) ->
     end.
 
 %% validates option spec
-validate_option(Path, #{name := Name} = Opt) when is_atom(Name); is_list(Name); is_binary(Name) ->
-    %% arguments cannot have unrecognised map items
-    Unknown = maps:keys(maps:without([name, help, short, long, action, nargs, type, default, required], Opt)),
-    Unknown =/= [] andalso fail({invalid_option, clean_path(Path), hd(Unknown), "unrecognised field"}),
+validate_option(Path, #{name := Name} = Arg) when is_atom(Name); is_list(Name); is_binary(Name) ->
     %% verify specific arguments
     %% help: string, 'hidden', or a tuple of {string(), ...}
-    is_valid_option_help(maps:get(help, Opt, [])) orelse
-        fail({invalid_option, clean_path(Path), Name, help, "must be a string or valid help template, ensure help template is a list"}),
-    io_lib:printable_unicode_list(maps:get(long, Opt, [])) orelse
-        fail({invalid_option, clean_path(Path), Name, long, "must be a printable string"}),
-    is_boolean(maps:get(required, Opt, true)) orelse
-        fail({invalid_option, clean_path(Path), Name, required, "must be boolean"}),
-    io_lib:printable_unicode_list([maps:get(short, Opt, $a)]) orelse
-        fail({invalid_option, clean_path(Path), Name, short, "must be a printable character"}),
-    Opt1 = maybe_validate(action, Opt, fun validate_action/3, Path),
+    is_valid_option_help(maps:get(help, Arg, [])) orelse
+        ?INVALID(argument, Arg, Path, help, <<"must be a string or valid help template">>),
+    io_lib:printable_unicode_list(maps:get(long, Arg, [])) orelse
+        ?INVALID(argument, Arg, Path, long, <<"must be a printable string">>),
+    is_boolean(maps:get(required, Arg, true)) orelse
+        ?INVALID(argument, Arg, Path, required, <<"must be a boolean">>),
+    io_lib:printable_unicode_list([maps:get(short, Arg, $a)]) orelse
+        ?INVALID(argument, Arg, Path, short, <<"must be a printable character">>),
+    Opt1 = maybe_validate(action, Arg, fun validate_action/3, Path),
     Opt2 = maybe_validate(type, Opt1, fun validate_type/3, Path),
     maybe_validate(nargs, Opt2, fun validate_args/3, Path);
-validate_option(Path, _Opt) ->
-    fail({invalid_option, clean_path(Path), "", name, "argument must be a map, and specify 'name'"}).
+validate_option(Path, Arg) ->
+    ?INVALID(argument, Arg, Path, name, <<"argument must be a map containing 'name' field">>).
 
 maybe_validate(Key, Map, Fun, Path) when is_map_key(Key, Map) ->
     maps:put(Key, Fun(maps:get(Key, Map), Path, Map), Map);
@@ -976,27 +966,27 @@ validate_action(count, _Path, _Opt) ->
 validate_action(extend, _Path, #{nargs := Nargs}) when
     Nargs =:= list; Nargs =:= nonempty_list; Nargs =:= all; is_integer(Nargs) ->
     extend;
-validate_action(extend, Path, #{name := Name}) ->
-    fail({invalid_option, clean_path(Path), Name, action, "extend action works only with lists"});
-validate_action(_Action, Path, #{name := Name}) ->
-    fail({invalid_option, clean_path(Path), Name, action, "unsupported"}).
+validate_action(extend, Path, Arg) ->
+    ?INVALID(argument, Arg, Path, action, <<"extend action works only with lists">>);
+validate_action(_Action, Path, Arg) ->
+    ?INVALID(argument, Arg, Path, action, <<"unsupported">>).
 
 %% validate type field
-validate_type(Simple, _Path, _Opt) when Simple =:= boolean; Simple =:= int; Simple =:= float;
+validate_type(Simple, _Path, _Opt) when Simple =:= boolean; Simple =:= integer; Simple =:= float;
     Simple =:= string; Simple =:= binary; Simple =:= atom; Simple =:= {atom, unsafe} ->
     Simple;
 validate_type({custom, Fun}, _Path, _Opt) when is_function(Fun, 1) ->
     {custom, Fun};
-validate_type({float, Opts}, Path, #{name := Name}) ->
-    [fail({invalid_option, clean_path(Path), Name, type, "invalid validator"})
+validate_type({float, Opts}, Path, Arg) ->
+    [?INVALID(argument, Arg, Path, type, <<"invalid validator">>)
         || {Kind, Val} <- Opts, (Kind =/= min andalso Kind =/= max) orelse (not is_float(Val))],
     {float, Opts};
-validate_type({int, Opts}, Path, #{name := Name}) ->
-    [fail({invalid_option, clean_path(Path), Name, type, "invalid validator"})
+validate_type({integer, Opts}, Path, Arg) ->
+    [?INVALID(argument, Arg, Path, type, <<"invalid validator">>)
         || {Kind, Val} <- Opts, (Kind =/= min andalso Kind =/= max) orelse (not is_integer(Val))],
-    {int, Opts};
-validate_type({atom, Choices} = Valid, Path, #{name := Name}) when is_list(Choices) ->
-    [fail({invalid_option, clean_path(Path), Name, type, "unsupported"}) || C <- Choices, not is_atom(C)],
+    {integer, Opts};
+validate_type({atom, Choices} = Valid, Path, Arg) when is_list(Choices) ->
+    [?INVALID(argument, Arg, Path, type, <<"unsupported">>) || C <- Choices, not is_atom(C)],
     Valid;
 validate_type({string, Re} = Valid, _Path, _Opt) when is_list(Re) ->
     Valid;
@@ -1008,19 +998,20 @@ validate_type({binary, Choices} = Valid, _Path, _Opt) when is_list(Choices), is_
     Valid;
 validate_type({binary, Re, L} = Valid, _Path, _Opt) when is_binary(Re), is_list(L) ->
     Valid;
-validate_type(_Type, Path, #{name := Name}) ->
-    fail({invalid_option, clean_path(Path), Name, type, "unsupported"}).
+validate_type(_Type, Path, Arg) ->
+    ?INVALID(argument, Arg, Path, type, <<"unsupported">>).
 
 validate_args(N, _Path, _Opt) when is_integer(N), N >= 1 -> N;
 validate_args(Simple, _Path, _Opt) when Simple =:= all; Simple =:= list; Simple =:= 'maybe'; Simple =:= nonempty_list ->
     Simple;
 validate_args({'maybe', Term}, _Path, _Opt) -> {'maybe', Term};
-validate_args(_Nargs, Path, #{name := Name}) ->
-    fail({invalid_option, clean_path(Path), Name, nargs, "unsupported"}).
+validate_args(_Nargs, Path, Arg) ->
+    ?INVALID(argument, Arg, Path, nargs, <<"unsupported">>).
 
 %% used to throw an error - strips command component out of path
 clean_path(Path) ->
-    [Cmd || {Cmd, _} <- Path].
+    {Cmds, _} = lists:unzip(Path),
+    lists:reverse(Cmds).
 
 is_valid_option_help(hidden) ->
     true;
@@ -1037,39 +1028,11 @@ is_valid_option_help(_) ->
 %%--------------------------------------------------------------------
 %% Built-in Help formatter
 
-%% Example format:
-%%
-%% usage: utility [-rxvf] [-i <int>] [--float <float>] <command> [<ARGS>]
-%%
-%% Commands:
-%%   start   verifies configuration and starts server
-%%   stop    stops running server
-%%
-%% Optional arguments:
-%%  -r       recursive
-%%  -v       increase verbosity level
-%%  -f       force
-%%  -i <int> interval set
-%%  --float <float> floating-point long form argument
-%%
-
-%% Example for deeper nested help (amount of flags reduced from previous example)
-%%
-%% usage: utility [-rz] [-i <int>] start <SERVER> [<NAME>]
-%%
-%% Optional arguments:
-%%  -r       recursive
-%%  -z       use zlib compression
-%%  -i <int> integer variable
-%%  SERVER   server to start
-%%  NAME     extra name to pass
-%%
-
-format_help({RootCmd, Root}, Format) ->
+format_help({ProgName, Root}, Format) ->
     Prefix = hd(maps:get(prefixes, Format, [$-])),
     Nested = maps:get(command, Format, []),
     %% descent into commands collecting all options on the way
-    {_CmdName, Cmd, AllArgs} = collect_options(RootCmd, Root, Nested, []),
+    {_CmdName, Cmd, AllArgs} = collect_options(ProgName, Root, Nested, []),
     %% split arguments into Flags, Options, Positional, and create help lines
     {_, Longest, Flags, Opts, Args, OptL, PosL} = lists:foldl(fun format_opt_help/2,
         {Prefix, 0, "", [], [], [], []}, AllArgs),
@@ -1083,33 +1046,47 @@ format_help({RootCmd, Root}, Format) ->
             {max(Long, string:length(Name)), [{Name, Help}|SubAcc]}
         end, {Longest, []}, Immediate),
     %% format sub-commands
-    SubFormat = io_lib:format("  ~~-~bts ~~ts~n", [Long]),
-    Commands = [io_lib:format(SubFormat, [N, D]) || {N, D} <- lists:reverse(Subs)],
-    ShortCmd =
+    ShortCmd0 =
         case map_size(Immediate) of
-            0 when Nested =:= [] ->
-                "";
             0 ->
-                [$ | lists:concat(lists:join(" ", Nested))];
+                [];
             Small when Small < 4 ->
-                " " ++ lists:concat(lists:join(" ", Nested)) ++  " {" ++
-                    lists:concat(lists:join("|", maps:keys(Immediate))) ++ "}";
+                ["{" ++ lists:concat(lists:join("|", maps:keys(Immediate))) ++ "}"];
             _Largs ->
-                io_lib:format("~ts <command>", [lists:concat(lists:join(" ", Nested))])
+                ["<command>"]
         end,
+    %% was it nested command?
+    ShortCmd = if Nested =:= [] -> ShortCmd0; true -> [lists:concat(lists:join(" ", Nested)) | ShortCmd0] end,
     %% format flags
-    FlagsForm = if Flags =:=[] -> ""; true -> io_lib:format(" [~tc~ts]", [Prefix, Flags]) end,
+    FlagsForm = if Flags =:= [] -> [];
+                    true -> [unicode:characters_to_list(io_lib:format("[~tc~ts]", [Prefix, Flags]))]
+                end,
     %% format extended view
-    OptFormat = io_lib:format("  ~~-~bts ~~ts~n", [Longest]),
-    %% split OptLines into positional and optional arguments
-    FormattedOpts = [io_lib:format(OptFormat, [Hdr, Dsc]) || {Hdr, Dsc} <- lists:reverse(OptL)],
-    FormattedArgs = [io_lib:format(OptFormat, [Hdr, Dsc]) || {Hdr, Dsc} <- lists:reverse(PosL)],
-    %% format first usage line
-    io_lib:format("usage: ~ts~ts~ts~ts~ts~ts~n~ts~ts~ts", [RootCmd, ShortCmd, FlagsForm, Opts, Args,
-        maybe_add("~n~ts", maps:get(help, Root, "")),
-        maybe_add("~nSubcommands:~n~ts", Commands),
-        maybe_add("~nArguments:~n~ts", FormattedArgs),
-        maybe_add("~nOptional arguments:~n~ts", FormattedOpts)]).
+    %% usage line has hardcoded format for now
+    Usage = [ProgName, ShortCmd, FlagsForm, Opts, Args],
+    %% format usage according to help template
+    Template0 = maps:get(help, Root, ""),
+    %% when there is no help defined for the command, or help is a string,
+    %% use the default format (original argparse behaviour)
+    Template =
+        case Template0 =:= "" orelse io_lib:printable_unicode_list(Template0) of
+            true ->
+                %% classic/compatibility format
+                NL = [io_lib:nl()],
+                Template1 = ["Usage:" ++ NL, usage, NL],
+                Template2 = maybe_add("~n", Template0, Template0 ++ NL, Template1),
+                Template3 = maybe_add("~nSubcommands:~n", Subs, commands, Template2),
+                Template4 = maybe_add("~nArguments:~n", PosL, arguments, Template3),
+                maybe_add("~nOptional arguments:~n", OptL, options, Template4);
+            false ->
+                Template0
+        end,
+
+    %% produce formatted output, taking viewport width into account
+    Parts = #{usage => Usage, commands => {Long, Subs},
+        arguments => {Longest, PosL}, options => {Longest, OptL}},
+    Width = maps:get(columns, Format, 80), %% might also use io:columns() here
+    lists:concat([format_width(maps:find(Part, Parts), Part, Width) || Part <- Template]).
 
 %% collects options on the Path, and returns found Command
 collect_options(CmdName, Command, [], Args) ->
@@ -1120,10 +1097,47 @@ collect_options(CmdName, Command, [Cmd|Tail], Args) ->
     collect_options(CmdName ++ " " ++ Cmd, SubCmd, Tail, maps:get(arguments, Command, []) ++ Args).
 
 %% conditionally adds text and empty lines
-maybe_add(_ToAdd, []) ->
-    [];
-maybe_add(ToAdd, List) ->
-    io_lib:format(ToAdd, [List]).
+maybe_add(_ToAdd, [], _Element, Template) ->
+    Template;
+maybe_add(ToAdd, _List, Element, Template) ->
+    Template ++ [io_lib:format(ToAdd, []), Element].
+
+format_width(error, Part, Width) ->
+    wordwrap(Part, 0, Width);
+format_width({ok, [ProgName, ShortCmd, FlagsForm, Opts, Args]}, usage, Width) ->
+    %% make every separate command/option to be a "word", and then
+    %% wordwrap it indented by the ProgName length + 3
+    Words = ShortCmd ++ FlagsForm ++ Opts ++ Args,
+    if Words =:= [] -> io_lib:format("  ~ts", [ProgName]);
+        true ->
+            Indent = string:length(ProgName),
+            Wrapped = wrap(Words, Width - Indent, 0, [], []),
+            Pad = lists:duplicate(Indent + 3, " "),
+            ArgLines = lists:join([io_lib:nl() | Pad], Wrapped),
+            io_lib:format("  ~ts ~ts", [ProgName, ArgLines])
+    end;
+format_width({ok, {Len, Texts}}, _Part, Width) ->
+    SubFormat = io_lib:format("  ~~-~bts ~~ts~n", [Len]),
+    [io_lib:format(SubFormat, [N, wordwrap(D, Len + 3, Width)]) || {N, D} <- lists:reverse(Texts)].
+
+wordwrap(Text, Indent, Width) ->
+    Lines = wrap(string:split(Text, " ", all), Width - Indent, 0, [], []),
+    NL = io_lib:nl(),
+    Pad = lists:duplicate(Indent, " "),
+    lists:join([NL | Pad], Lines).
+
+wrap([], _Max, _Len, Line, Lines) ->
+    lists:reverse([Line | Lines]);
+wrap([Word | Tail], Max, Len, Line, Lines) ->
+    WordLen = string:length(Word),
+    case Len + 1 + WordLen > Max of
+        true ->
+            wrap(Tail, Max, WordLen, Word, [Line | Lines]);
+        false when Line =:= [] ->
+            wrap(Tail, Max, WordLen + 1 + Len, Word, Lines);
+        false ->
+            wrap(Tail, Max, WordLen + 1 + Len, Line ++ [$ | Word], Lines)
+    end.
 
 %% create help line for every option, collecting together all flags, short options,
 %%  long options, and positional arguments
@@ -1131,7 +1145,7 @@ maybe_add(ToAdd, List) ->
 %% format optional argument
 format_opt_help(#{help := hidden}, Acc) ->
     Acc;
-format_opt_help(Opt, {Prefix, Longest, Flags, Opts, Args, OptL, PosL}) when ?IS_OPTIONAL(Opt) ->
+format_opt_help(Opt, {Prefix, Longest, Flags, Opts, Args, OptL, PosL}) when ?IS_OPTION(Opt) ->
     Desc = format_description(Opt),
     %% does it need an argument? look for nargs and action
     RequiresArg = requires_argument(Opt),
@@ -1149,10 +1163,10 @@ format_opt_help(Opt, {Prefix, Longest, Flags, Opts, Args, OptL, PosL}) when ?IS_
                 {FN, [format_required(false, FN ++ " ", Opt)]};
             {ok, Long} when NonOption ->
                 FN = [Prefix | Long],
-                {FN, [[$ |FN]]};
+                {FN, [FN]};
             {ok, Long} ->
                 FN = [Prefix | Long],
-                {FN, [io_lib:format(" [~ts]", [FN])]}
+                {FN, [io_lib:format("[~ts]", [FN])]}
         end,
     %% short may go to flags, or Opts
     {Name, MaybeFlag, MaybeOpt1} =
@@ -1170,7 +1184,7 @@ format_opt_help(Opt, {Prefix, Longest, Flags, Opts, Args, OptL, PosL}) when ?IS_
     MaybeOpt2 =
         case maps:find(help, Opt) of
             {ok, {Str, _}} ->
-                [$ | Str];
+                [Str];
             _ ->
                 MaybeOpt1
         end,
@@ -1186,11 +1200,11 @@ format_opt_help(#{name := Name} = Opt, {Prefix, Longest, Flags, Opts, Args, OptL
     LName = io_lib:format("~ts", [Name]),
     LPos = case maps:find(help, Opt) of
                {ok, {Str, _}} ->
-                   [$ | Str];
+                   Str;
                _ ->
                    format_required(maps:get(required, Opt, true), "", Opt)
            end,
-    {Prefix, max(Longest, string:length(LName)), Flags, Opts, Args ++ LPos, OptL, [{LName, Desc}|PosL]}.
+    {Prefix, max(Longest, string:length(LName)), Flags, Opts, Args ++ [LPos], OptL, [{LName, Desc} | PosL]}.
 
 %% custom format
 format_description(#{help := {_Short, Fun}}) when is_function(Fun, 0) ->
@@ -1223,29 +1237,29 @@ maybe_concat(No, []) -> No;
 maybe_concat(No, L) -> No ++ ", " ++ L.
 
 format_required(true, Extra, #{name := Name} = Opt) ->
-    io_lib:format(" ~ts<~ts>~ts", [Extra, Name, format_nargs(Opt)]);
+    io_lib:format("~ts<~ts>~ts", [Extra, Name, format_nargs(Opt)]);
 format_required(false, Extra, #{name := Name} = Opt) ->
-    io_lib:format(" [~ts<~ts>~ts]", [Extra, Name, format_nargs(Opt)]).
+    io_lib:format("[~ts<~ts>~ts]", [Extra, Name, format_nargs(Opt)]).
 
 format_nargs(#{nargs := Dots}) when Dots =:= list; Dots =:= all; Dots =:= nonempty_list ->
     "...";
 format_nargs(_) ->
     "".
 
-format_type(#{type := {int, Choices}}) when is_list(Choices), is_integer(hd(Choices)) ->
+format_type(#{type := {integer, Choices}}) when is_list(Choices), is_integer(hd(Choices)) ->
     io_lib:format("choice: ~s", [lists:join(", ", [integer_to_list(C) || C <- Choices])]);
 format_type(#{type := {float, Choices}}) when is_list(Choices), is_number(hd(Choices)) ->
     io_lib:format("choice: ~s", [lists:join(", ", [io_lib:format("~g", [C]) || C <- Choices])]);
-format_type(#{type := {Num, Valid}}) when Num =:= int; Num =:= float ->
+format_type(#{type := {Num, Valid}}) when Num =:= integer; Num =:= float ->
     case {proplists:get_value(min, Valid), proplists:get_value(max, Valid)} of
         {undefined, undefined} ->
-            io_lib:format("~s", [Num]);
+            io_lib:format("~s", [format_type(#{type => Num})]);
         {Min, undefined} ->
-            io_lib:format("~s >= ~tp", [Num, Min]);
+            io_lib:format("~s >= ~tp", [format_type(#{type => Num}), Min]);
         {undefined, Max} ->
-            io_lib:format("~s <= ~tp", [Num, Max]);
+            io_lib:format("~s <= ~tp", [format_type(#{type => Num}), Max]);
         {Min, Max} ->
-            io_lib:format("~tp <= ~s <= ~tp", [Min, Num, Max])
+            io_lib:format("~tp <= ~s <= ~tp", [Min, format_type(#{type => Num}), Max])
     end;
 format_type(#{type := {string, Re, _}}) when is_list(Re), not is_list(hd(Re)) ->
     io_lib:format("string re: ~ts", [Re]);
@@ -1265,6 +1279,8 @@ format_type(#{type := {atom, Choices}}) ->
     io_lib:format("choice: ~ts", [lists:join(", ", [atom_to_list(C) || C <- Choices])]);
 format_type(#{type := boolean}) ->
     "";
+format_type(#{type := integer}) ->
+    "int";
 format_type(#{type := Type}) when is_atom(Type) ->
     io_lib:format("~ts", [Type]);
 format_type(_Opt) ->
@@ -1276,3 +1292,33 @@ format_default(#{default := Def}) ->
     io_lib:format("~tp", [Def]);
 format_default(_) ->
     "".
+
+%%--------------------------------------------------------------------
+%% Basic handler execution
+handle(CmdMap, ArgMap, Path, #{handler := {Mod, ModFun, Default}}) ->
+    ArgList = arg_map_to_arg_list(CmdMap, Path, ArgMap, Default),
+    %% if argument count may not match, better error can be produced
+    erlang:apply(Mod, ModFun, ArgList);
+handle(_CmdMap, ArgMap, _Path, #{handler := {Mod, ModFun}}) when is_atom(Mod), is_atom(ModFun) ->
+    Mod:ModFun(ArgMap);
+handle(CmdMap, ArgMap, Path, #{handler := {Fun, Default}}) when is_function(Fun) ->
+    ArgList = arg_map_to_arg_list(CmdMap, Path, ArgMap, Default),
+    %% if argument count may not match, better error can be produced
+    erlang:apply(Fun, ArgList);
+handle(_CmdMap, ArgMap, _Path, #{handler := Handler}) when is_function(Handler, 1) ->
+    Handler(ArgMap).
+
+%% Given command map, path to reach a specific command, and a parsed argument
+%%  map, returns a list of arguments (effectively used to transform map-based
+%%  callback handler into positional).
+arg_map_to_arg_list(Command, Path, ArgMap, Default) ->
+    AllArgs = collect_arguments(Command, Path, []),
+    [maps:get(Arg, ArgMap, Default) || #{name := Arg} <- AllArgs].
+
+%% recursively descend into Path, ignoring arguments with duplicate names
+collect_arguments(Command, [], Acc) ->
+    Acc ++ maps:get(arguments, Command, []);
+collect_arguments(Command, [H|Tail], Acc) ->
+    Args = maps:get(arguments, Command, []),
+    Next = maps:get(H, maps:get(commands, Command, H)),
+    collect_arguments(Next, Tail, Acc ++ Args).

--- a/src/args.erl
+++ b/src/args.erl
@@ -15,7 +15,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 
--module(argparse).
+-module(args).
 -author("maximfca@gmail.com").
 
 %% API Exports
@@ -245,8 +245,8 @@ run(Args, Command, Options) ->
         {ok, ArgMap, Path, SubCmd} ->
             handle(Command, ArgMap, tl(Path), SubCmd);
         {error, Reason} ->
-            io:format("error: ~ts~n", [argparse:format_error(Reason)]),
-            io:format("~ts", [argparse:help(Command, Options#{command => tl(element(1, Reason))})]),
+            io:format("error: ~ts~n", [format_error(Reason)]),
+            io:format("~ts", [help(Command, Options#{command => tl(element(1, Reason))})]),
             erlang:halt(1)
     catch
         error:Reason:Stack ->
@@ -763,7 +763,7 @@ convert_type({atom, Choices}, Arg, Opt, Eos) ->
 convert_type({custom, Fun}, Arg, Opt, Eos) ->
     try Fun(Arg)
     catch error:badarg ->
-        throw({Eos#eos.commands, Opt, Arg, <<"failed faildation">>})
+        throw({Eos#eos.commands, Opt, Arg, <<"failed validation">>})
     end.
 
 %% Given Var, and list of {min, X}, {max, Y}, ensure that

--- a/test/argparse_SUITE.erl
+++ b/test/argparse_SUITE.erl
@@ -135,9 +135,9 @@ ubiq_cmd() ->
                     #{name => fc, short => $q, type => {float, [2.1,1.2]}, help => "floating choice"},
                     #{name => ac, short => $w, type => {atom, [one, two]}, help => "atom choice"},
                     #{name => au, long => "-unsafe", type => {atom, unsafe}, help => "unsafe atom"},
-                    #{name => as, long => "-safe", type => atom, help => "safe atom"},
+                    #{name => as, long => "-safe", type => atom, help => <<"safe atom">>},
                     #{name => name, required => false, nargs => list, help => hidden},
-                    #{name => long, long => "foobar", required => false, help => "foobaring option"}
+                    #{name => long, long => "foobar", required => false, help => [<<"foobaring option">>]}
                 ], commands => #{
                     "crawler" => #{arguments => [
                         #{name => extra, long => "--extra", help => "extra option very deep"}
@@ -145,7 +145,7 @@ ubiq_cmd() ->
                         help => "controls crawler behaviour"},
                     "doze" => #{help => "dozes a bit"}}
             },
-            "stop" => #{help => "stops running server", arguments => []
+            "stop" => #{help => <<"stops running server">>, arguments => []
             },
             "status" => #{help => "prints server status", arguments => [],
                 commands => #{
@@ -271,13 +271,13 @@ type_validators(Config) when is_list(Config) ->
         parse_opts("me", [#{name => str, type => {string, "m."}}])),
     ?assertMatch({ok, #{str := "me"}, _, _},
         parse_opts("me", [#{name => str, type => {string, "m.", []}}])),
-    ?assertMatch({ok, #{str := "me"}, _, _},
-        parse_opts("me", [#{name => str, type => {string, "m.", [{capture, none}]}}])),
+    ?assertMatch({ok, #{"str" := "me"}, _, _},
+        parse_opts("me", [#{name => "str", type => {string, "m.", [{capture, none}]}}])),
     %% and binary too...
     ?assertMatch({ok, #{bin := <<"me">>}, _, _},
         parse_opts("me", [#{name => bin, type => {binary, <<"m.">>}}])),
-    ?assertMatch({ok, #{bin := <<"me">>}, _, _},
-        parse_opts("me", [#{name => bin, type => {binary, <<"m.">>, []}}])),
+    ?assertMatch({ok, #{<<"bin">> := <<"me">>}, _, _},
+        parse_opts("me", [#{name => <<"bin">>, type => {binary, <<"m.">>, []}}])),
     ?assertMatch({ok, #{bin := <<"me">>}, _, _},
         parse_opts("me", [#{name => bin, type => {binary, <<"m.">>, [{capture, none}]}}])),
     %% successful integer with range validators
@@ -818,7 +818,7 @@ usage_template(Config) when is_list(Config) ->
         name => shard,
         type => integer,
         default => 0,
-        help => {"[-s SHARD]", ["initial number, ", type, " with a default value of ", default]}}
+        help => {"[-s SHARD]", ["initial number, ", type, <<" with a default value of ">>, default]}}
     ]},
     ?assertEqual("Usage:\n  " ++ prog() ++ " [-s SHARD]\n\nArguments:\n  shard initial number, int with a default value of 0\n",
         unicode:characters_to_list(argparse:help(Cmd, #{}))),
@@ -828,7 +828,7 @@ usage_template(Config) when is_list(Config) ->
         short => $s,
         type => integer,
         default => 0,
-        help => {"[-s SHARD]", ["initial number"]}}
+        help => {<<"[-s SHARD]">>, ["initial number"]}}
     ]},
     ?assertEqual("Usage:\n  " ++ prog() ++ " [-s SHARD]\n\nOptional arguments:\n  -s initial number\n",
         unicode:characters_to_list(argparse:help(Cmd1, #{}))),
@@ -878,7 +878,7 @@ command_usage() ->
 command_usage(Config) when is_list(Config) ->
     Cmd = #{arguments => [
         #{name => arg, help => "argument help"}, #{name => opt, short => $o, help => "option help"}],
-        help => ["Options:\n", options, arguments, "NOTAUSAGE", usage, "\n"]
+        help => ["Options:\n", options, arguments, <<"NOTAUSAGE">>, usage, "\n"]
     },
     ?assertEqual("Options:\n  -o  option help\n  arg argument help\nNOTAUSAGE  " ++ prog() ++ " [-o <opt>] <arg>\n",
         unicode:characters_to_list(argparse:help(Cmd, #{}))).
@@ -895,17 +895,22 @@ usage_width(Config) when is_list(Config) ->
         #{name => q, short => $q, type => boolean}],
         commands => #{
             "cmd1" => #{help => "Help for command number 1, not fitting at all"},
-            "cmd2" => #{help => "Short help"},
+            "cmd2" => #{help => <<"Short help">>},
             "cmd3" => #{help => "Yet another instance of a very long help message"}
         },
-        help => "Very long help line taking much more than 40 characters allowed by the test case"
+        help => "  Very long help line taking much more than 40 characters allowed by the test case.
+Also containing a few newlines.
+
+   Indented new lines must be honoured!"
     },
 
     Expected = "Usage:\n  " ++ prog() ++ " {cmd1|cmd2|cmd3} [-vq] [-o <opt>]\n"
         "      [--option_long_name <opt>] <arg>\n\n"
-        "Very long help line taking much more\n"
+        "  Very long help line taking much more\n"
         "than 40 characters allowed by the test\n"
-        "case\n\n"
+        "case.\n"
+        "Also containing a few newlines.\n\n"
+        "   Indented new lines must be honoured!\n\n"
         "Subcommands:\n"
         "  cmd1                   Help for\n"
         "                         command number\n"

--- a/test/argparse_SUITE.erl
+++ b/test/argparse_SUITE.erl
@@ -1,59 +1,88 @@
-%%%-------------------------------------------------------------------
-%%% @copyright (C) 2020-2021, Maxim Fedorov <maximfca@mail.com>
-%%% @doc
-%%%  Tests for argparse library.
-%%% @end
+%%
+%%
+%% Copyright Maxim Fedorov
+%%
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
 -module(argparse_SUITE).
 -author("maximfca@gmail.com").
 
 -export([suite/0, all/0, groups/0]).
 
 -export([
+    readme/0, readme/1,
     basic/0, basic/1,
     long_form_eq/0, long_form_eq/1,
-    single_arg_built_in_types/0, single_arg_built_in_types/1,
+    built_in_types/0, built_in_types/1,
+    type_validators/0, type_validators/1,
+    invalid_arguments/0, invalid_arguments/1,
     complex_command/0, complex_command/1,
     unicode/0, unicode/1,
-    errors/0, errors/1,
-    args/0, args/1,
+    parser_error/0, parser_error/1,
+    nargs/0, nargs/1,
     argparse/0, argparse/1,
     negative/0, negative/1,
     nodigits/0, nodigits/1,
-    python_issue_15112/0, python_issue_15112/1,
+    pos_mixed_with_opt/0, pos_mixed_with_opt/1,
     default_for_not_required/0, default_for_not_required/1,
     global_default/0, global_default/1,
-    type_validators/0, type_validators/1,
-    error_format/0, error_format/1,
     subcommand/0, subcommand/1,
     very_short/0, very_short/1,
     multi_short/0, multi_short/1,
     proxy_arguments/0, proxy_arguments/1,
+
     usage/0, usage/1,
     usage_required_args/0, usage_required_args/1,
-    readme/0, readme/1,
-    error_usage/0, error_usage/1,
-    meta/0, meta/1,
-    usage_template/0, usage_template/1
+    usage_template/0, usage_template/1,
+    parser_error_usage/0, parser_error_usage/1,
+    command_usage/0, command_usage/1,
+    usage_width/0, usage_width/1,
+
+    validator_exception/0, validator_exception/1,
+    validator_exception_format/0, validator_exception_format/1,
+
+    run_handle/0, run_handle/1
 ]).
 
--include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
-
 suite() ->
-    [{timetrap, {seconds, 5}}].
+    [{timetrap, {seconds, 30}}].
 
 groups() ->
-    [{parallel, [parallel], [
-        basic, long_form_eq, single_arg_built_in_types, complex_command, errors,
-        unicode, args, argparse, negative, proxy_arguments, default_for_not_required,
-        nodigits,  python_issue_15112, type_validators, subcommand, error_format,
-        very_short, multi_short, usage, readme, error_usage, meta, usage_template,
-        global_default
-    ]}].
+    [
+        {parser, [parallel], [
+            readme, basic, long_form_eq, built_in_types, type_validators,
+            invalid_arguments, complex_command, unicode, parser_error,
+            nargs, argparse, negative, nodigits, pos_mixed_with_opt,
+            default_for_not_required, global_default, subcommand,
+            very_short, multi_short, proxy_arguments
+        ]},
+        {usage, [parallel], [
+            usage, usage_required_args, usage_template,
+            parser_error_usage, command_usage, usage_width
+        ]},
+        {validator, [parallel], [
+            validator_exception, validator_exception_format
+        ]},
+        {run, [parallel], [
+            run_handle
+        ]}
+    ].
 
 all() ->
-    [{group, parallel}].
+    [{group, parser}, {group, validator}, {group, usage}].
 
 %%--------------------------------------------------------------------
 %% Helpers
@@ -61,11 +90,9 @@ all() ->
 prog() ->
     {ok, [[ProgStr]]} = init:get_argument(progname), ProgStr.
 
-make_error(CmdLine, CmdMap) ->
-    try parse(CmdLine, CmdMap), exit(must_never_succeed)
-    catch error:{argparse, Reason} ->
-        argparse:format_error(Reason)
-    end.
+parser_error(CmdLine, CmdMap) ->
+    {error, Reason} = parse(CmdLine, CmdMap),
+    unicode:characters_to_list(argparse:format_error(Reason)).
 
 parse_opts(Args, Opts) ->
     argparse:parse(string:lexemes(Args, " "), #{arguments => Opts}).
@@ -76,14 +103,15 @@ parse(Args, Command) ->
 parse_cmd(Args, Command) ->
     argparse:parse(string:lexemes(Args, " "), #{commands => Command}).
 
-%% ubiquitous command - contains *every* combination
+%% ubiquitous command, containing sub-commands, and all possible option types
+%% with all nargs. Not all combinations though.
 ubiq_cmd() ->
     #{
         arguments => [
             #{name => r, short => $r, type => boolean, help => "recursive"},
             #{name => f, short => $f, type => boolean, long => "-force", help => "force"},
             #{name => v, short => $v, type => boolean, action => count, help => "verbosity level"},
-            #{name => interval, short => $i, type => {int, [{min, 1}]}, help => "interval set"},
+            #{name => interval, short => $i, type => {integer, [{min, 1}]}, help => "interval set"},
             #{name => weird, long => "-req", help => "required optional, right?"},
             #{name => float, long => "-float", type => float, default => 3.14, help => "floating-point long form argument"}
         ],
@@ -91,19 +119,19 @@ ubiq_cmd() ->
             "start" => #{help => "verifies configuration and starts server",
                 arguments => [
                     #{name => server, help => "server to start"},
-                    #{name => shard, short => $s, type => int, nargs => nonempty_list, help => "initial shards"},
-                    #{name => part, short => $p, type => int, nargs => list, help => hidden},
-                    #{name => z, short => $z, type => {int, [{min, 1}, {max, 10}]}, help => "between"},
-                    #{name => l, short => $l, type => {int, [{max, 10}]}, nargs => 'maybe', help => "maybe lower"},
-                    #{name => more, short => $m, type => {int, [{max, 10}]}, help => "less than 10"},
-                    #{name => optpos, required => false, type => {int, []}, help => "optional positional"},
+                    #{name => shard, short => $s, type => integer, nargs => nonempty_list, help => "initial shards"},
+                    #{name => part, short => $p, type => integer, nargs => list, help => hidden},
+                    #{name => z, short => $z, type => {integer, [{min, 1}, {max, 10}]}, help => "between"},
+                    #{name => l, short => $l, type => {integer, [{max, 10}]}, nargs => 'maybe', help => "maybe lower"},
+                    #{name => more, short => $m, type => {integer, [{max, 10}]}, help => "less than 10"},
+                    #{name => optpos, required => false, type => {integer, []}, help => "optional positional"},
                     #{name => bin, short => $b, type => {binary, <<"m">>}, help => "binary with re"},
                     #{name => g, short => $g, type => {binary, <<"m">>, []}, help => "binary with re"},
                     #{name => t, short => $t, type => {string, "m"}, help => "string with re"},
-                    #{name => e, long => "--maybe-req", required => true, type => int, nargs => 'maybe', help => "maybe required int"},
+                    #{name => e, long => "--maybe-req", required => true, type => integer, nargs => 'maybe', help => "maybe required int"},
                     #{name => y, required => true, long => "-yyy", short => $y, type => {string, "m", []}, help => "string with re"},
                     #{name => u, short => $u, type => {string, ["1", "2"]}, help => "string choices"},
-                    #{name => choice, short => $c, type => {int, [1,2,3]}, help => "tough choice"},
+                    #{name => choice, short => $c, type => {integer, [1,2,3]}, help => "tough choice"},
                     #{name => fc, short => $q, type => {float, [2.1,1.2]}, help => "floating choice"},
                     #{name => ac, short => $w, type => {atom, [one, two]}, help => "atom choice"},
                     #{name => au, long => "-unsafe", type => {atom, unsafe}, help => "unsafe atom"},
@@ -133,12 +161,13 @@ ubiq_cmd() ->
     }.
 
 %%--------------------------------------------------------------------
-%% Test Cases
+%% Parser Test Cases
 
 readme() ->
-    [{doc, "Test cases covered in README.md"}].
+    [{doc, "Test cases covered in the README"}].
 
 readme(Config) when is_list(Config) ->
+    Prog = prog(),
     Rm = #{
         arguments => [
             #{name => dir},
@@ -146,17 +175,18 @@ readme(Config) when is_list(Config) ->
             #{name => recursive, short => $r, type => boolean}
         ]
     },
-    ?assertEqual(#{dir => "dir", force => true, recursive => true},
-        argparse:parse(["-rf", "dir"], Rm, #{result => argmap})),
+    ?assertEqual({ok, #{dir => "dir", force => true, recursive => true}, [Prog], Rm},
+        argparse:parse(["-rf", "dir"], Rm)),
     %% override progname
-    ?assertEqual("usage: readme\n",
-        argparse:help(#{}, #{progname => "readme"})),
-    ?assertEqual("usage: readme\n",
-        argparse:help(#{}, #{progname => readme})),
-    ?assertException(error, {argparse,
-        {invalid_command, [], progname, "progname must be a list or an atom"}},
-        argparse:help(#{}, #{progname => 123})),
-    %% command example
+    ?assertEqual("Usage:\n  readme\n",
+        unicode:characters_to_list(argparse:help(#{}, #{progname => "readme"}))),
+    ?assertEqual("Usage:\n  readme\n",
+        unicode:characters_to_list(argparse:help(#{}, #{progname => readme}))),
+    ?assertEqual("Usage:\n  readme\n",
+        unicode:characters_to_list(argparse:help(#{}, #{progname => <<"readme">>}))),
+    %% test that command has priority over just a positional argument:
+    %%  - parsing "opt sub" means "find positional argument "pos", then enter subcommand
+    %%  - parsing "sub opt" means "enter sub-command, and then find positional argument"
     Cmd = #{
         commands => #{"sub" => #{}},
         arguments => [#{name => pos}]
@@ -167,145 +197,174 @@ basic() ->
     [{doc, "Basic cases"}].
 
 basic(Config) when is_list(Config) ->
+    Prog = prog(),
     %% empty command, with full options path
-    ?assertMatch({#{}, {["cmd"],#{}}},
-        argparse:parse(["cmd"], #{commands => #{"cmd" => #{}}}, #{result => full})),
+    ?assertMatch({ok, #{}, [Prog, "cmd"], #{}},
+        argparse:parse(["cmd"], #{commands => #{"cmd" => #{}}})),
     %% sub-command, with no path, but user-supplied argument
-    ?assertEqual({#{},{["cmd", "sub"],#{attr => pos}}},
+    ?assertEqual({ok, #{}, [Prog, "cmd", "sub"], #{attr => pos}},
         argparse:parse(["cmd", "sub"], #{commands => #{"cmd" => #{commands => #{"sub" => #{attr => pos}}}}})),
     %% command with positional argument
     PosCmd = #{arguments => [#{name => pos}]},
-    ?assertEqual({#{pos => "arg"}, {["cmd"], PosCmd}},
+    ?assertEqual({ok, #{pos => "arg"}, [Prog, "cmd"], PosCmd},
         argparse:parse(["cmd", "arg"], #{commands => #{"cmd" => PosCmd}})),
     %% command with optional argument
     OptCmd = #{arguments => [#{name => force, short => $f, type => boolean}]},
-    ?assertEqual({#{force => true}, {["rm"], OptCmd}},
+    ?assertEqual({ok, #{force => true}, [Prog, "rm"], OptCmd},
         parse(["rm -f"], #{commands => #{"rm" => OptCmd}}), "rm -f"),
     %% command with optional and positional argument
     PosOptCmd = #{arguments => [#{name => force, short => $f, type => boolean}, #{name => dir}]},
-    ?assertEqual({#{force => true, dir => "dir"}, {["rm"], PosOptCmd}},
+    ?assertEqual({ok, #{force => true, dir => "dir"}, [Prog, "rm"], PosOptCmd},
         parse(["rm -f dir"], #{commands => #{"rm" => PosOptCmd}}), "rm -f dir"),
     %% no command, just argument list
-    Kernel = #{name => kernel, long => "kernel", type => atom, nargs => 2},
-    ?assertEqual(#{kernel => [port, dist]},
-        parse(["-kernel port dist"], #{arguments => [Kernel]})),
+    KernelCmd = #{arguments => [#{name => kernel, long => "kernel", type => atom, nargs => 2}]},
+    ?assertEqual({ok, #{kernel => [port, dist]}, [Prog], KernelCmd},
+        parse(["-kernel port dist"], KernelCmd)),
     %% same but positional
-    ArgList = #{name => arg, nargs => 2, type => boolean},
-    ?assertEqual(#{arg => [true, false]},
-        parse(["true false"], #{arguments => [ArgList]})).
+    ArgListCmd = #{arguments => [#{name => arg, nargs => 2, type => boolean}]},
+    ?assertEqual({ok, #{arg => [true, false]}, [Prog], ArgListCmd},
+        parse(["true false"], ArgListCmd)).
 
 long_form_eq() ->
     [{doc, "Tests that long form supports --arg=value"}].
 
 long_form_eq(Config) when is_list(Config) ->
+    Prog = prog(),
     %% cmd --arg=value
     PosOptCmd = #{arguments => [#{name => arg, long => "-arg"}]},
-    ?assertEqual({#{arg => "value"}, {["cmd"], PosOptCmd}},
+    ?assertEqual({ok, #{arg => "value"}, [Prog, "cmd"], PosOptCmd},
         parse(["cmd --arg=value"], #{commands => #{"cmd" => PosOptCmd}})),
-    %% --int=10
-    ?assertEqual(#{int => 10}, parse(["--int=10"], #{arguments => [#{name => int, type => int, long => "-int"}]})).
+    %% --integer=10
+    ?assertMatch({ok, #{int := 10}, _, _},
+        parse(["--int=10"], #{arguments => [#{name => int, type => integer, long => "-int"}]})).
 
-single_arg_built_in_types() ->
+built_in_types() ->
     [{doc, "Tests all built-in types supplied as a single argument"}].
 
 % built-in types testing
-single_arg_built_in_types(Config) when is_list(Config) ->
+built_in_types(Config) when is_list(Config) ->
+    Prog = [prog()],
     Bool = #{arguments => [#{name => meta, type => boolean, short => $b, long => "-boolean"}]},
-    ?assertEqual(#{}, parse([""], Bool)),
-    ?assertEqual(#{meta => true}, parse(["-b"], Bool)),
-    ?assertEqual(#{meta => true}, parse(["--boolean"], Bool)),
-    ?assertEqual(#{meta => false}, parse(["--boolean false"], Bool)),
+    ?assertEqual({ok, #{}, Prog, Bool}, parse([""], Bool)),
+    ?assertEqual({ok, #{meta => true}, Prog, Bool}, parse(["-b"], Bool)),
+    ?assertEqual({ok, #{meta => true}, Prog, Bool}, parse(["--boolean"], Bool)),
+    ?assertEqual({ok, #{meta => false}, Prog, Bool}, parse(["--boolean false"], Bool)),
     %% integer tests
-    Int = #{arguments => [#{name => int, type => int, short => $i, long => "-int"}]},
-    ?assertEqual(#{int => 1}, parse([" -i 1"], Int)),
-    Prog = prog(),
-    ?assertException(error, {argparse,{invalid_argument,[Prog],int,"1,"}}, parse([" -i 1, 3"], Int)),
-    ?assertEqual(#{int => 1}, parse(["--int 1"], Int)),
-    ?assertEqual(#{int => -1}, parse(["-i -1"], Int)),
+    Int = #{arguments => [#{name => int, type => integer, short => $i, long => "-int"}]},
+    ?assertEqual({ok, #{int => 1}, Prog, Int}, parse([" -i 1"], Int)),
+    ?assertEqual({ok, #{int => 1}, Prog, Int}, parse(["--int 1"], Int)),
+    ?assertEqual({ok, #{int => -1}, Prog, Int}, parse(["-i -1"], Int)),
     %% floating point
     Float = #{arguments => [#{name => f, type => float, short => $f}]},
-    ?assertEqual(#{f => 44.44}, parse(["-f 44.44"], Float)),
+    ?assertEqual({ok, #{f => 44.44}, Prog, Float}, parse(["-f 44.44"], Float)),
     %% atoms, existing
     Atom = #{arguments => [#{name => atom, type => atom, short => $a, long => "-atom"}]},
-    ?assertEqual(#{atom => atom}, parse(["-a atom"], Atom)),
-    ?assertEqual(#{atom => atom}, parse(["--atom atom"], Atom)).
+    ?assertEqual({ok, #{atom => atom}, Prog, Atom}, parse(["-a atom"], Atom)),
+    ?assertEqual({ok, #{atom => atom}, Prog, Atom}, parse(["--atom atom"], Atom)).
 
 type_validators() ->
-    [{doc, "Validators for built-in types"}].
+    [{doc, "Test that parser return expected conversions for valid arguments"}].
 
 type_validators(Config) when is_list(Config) ->
+    %% successful string regexes
+    ?assertMatch({ok, #{str := "me"}, _, _},
+        parse_opts("me", [#{name => str, type => {string, "m."}}])),
+    ?assertMatch({ok, #{str := "me"}, _, _},
+        parse_opts("me", [#{name => str, type => {string, "m.", []}}])),
+    ?assertMatch({ok, #{str := "me"}, _, _},
+        parse_opts("me", [#{name => str, type => {string, "m.", [{capture, none}]}}])),
+    %% and binary too...
+    ?assertMatch({ok, #{bin := <<"me">>}, _, _},
+        parse_opts("me", [#{name => bin, type => {binary, <<"m.">>}}])),
+    ?assertMatch({ok, #{bin := <<"me">>}, _, _},
+        parse_opts("me", [#{name => bin, type => {binary, <<"m.">>, []}}])),
+    ?assertMatch({ok, #{bin := <<"me">>}, _, _},
+        parse_opts("me", [#{name => bin, type => {binary, <<"m.">>, [{capture, none}]}}])),
+    %% successful integer with range validators
+    ?assertMatch({ok, #{int := 5}, _, _},
+        parse_opts("5", [#{name => int, type => {integer, [{min, 0}, {max, 10}]}}])),
+    ?assertMatch({ok, #{bin := <<"5">>}, _, _},
+        parse_opts("5", [#{name => bin, type => binary}])),
+    ?assertMatch({ok, #{str := "011"}, _, _},
+        parse_opts("11", [#{name => str, type => {custom, fun(S) -> [$0|S] end}}])),
+    %% choices: valid
+    ?assertMatch({ok, #{bin := <<"K">>}, _, _},
+        parse_opts("K", [#{name => bin, type => {binary, [<<"M">>, <<"K">>]}}])),
+    ?assertMatch({ok, #{str := "K"}, _, _},
+        parse_opts("K", [#{name => str, type => {string, ["K", "N"]}}])),
+    ?assertMatch({ok, #{atom := one}, _, _},
+        parse_opts("one", [#{name => atom, type => {atom, [one, two]}}])),
+    ?assertMatch({ok, #{int := 12}, _, _},
+        parse_opts("12", [#{name => int, type => {integer, [10, 12]}}])),
+    ?assertMatch({ok, #{float := 1.3}, _, _},
+        parse_opts("1.3", [#{name => float, type => {float, [1.3, 1.4]}}])),
+    %% test for unsafe atom
+    %% ensure the atom does not exist
+    ?assertException(error, badarg, list_to_existing_atom("$can_never_be")),
+    {ok, ArgMap, _, _} = parse_opts("$can_never_be", [#{name => atom, type => {atom, unsafe}}]),
+    argparse:validate(#{arguments => [#{name => atom, type => {atom, unsafe}}]}),
+    %% now that atom exists, because argparse created it (in an unsafe way!)
+    ?assertEqual(list_to_existing_atom("$can_never_be"), maps:get(atom, ArgMap)),
+    %% test successful user-defined conversion
+    ?assertMatch({ok, #{user := "VER"}, _, _},
+        parse_opts("REV", [#{name => user, type => {custom, fun (Str) -> lists:reverse(Str) end}}])).
+
+invalid_arguments() ->
+    [{doc, "Test that parser return errors for invalid arguments"}].
+
+invalid_arguments(Config) when is_list(Config) ->
     %% {float, [{min, float()} | {max, float()}]} |
     Prog = [prog()],
-    ?assertException(error, {argparse, {invalid_argument,Prog,float, 0.0}},
-        parse_opts("0.0", [#{name => float, type => {float, [{min, 1.0}]}}])),
-    ?assertException(error, {argparse, {invalid_argument,Prog,float, 2.0}},
-        parse_opts("2.0", [#{name => float, type => {float, [{max, 1.0}]}}])),
+    MinFloat = #{name => float, type => {float, [{min, 1.0}]}},
+    ?assertEqual({error, {Prog, MinFloat, "0.0", <<"is less than accepted minimum">>}},
+        parse_opts("0.0", [MinFloat])),
+    MaxFloat = #{name => float, type => {float, [{max, 1.0}]}},
+    ?assertEqual({error, {Prog, MaxFloat, "2.0", <<"is greater than accepted maximum">>}},
+        parse_opts("2.0", [MaxFloat])),
     %% {int, [{min, integer()} | {max, integer()}]} |
-    ?assertException(error, {argparse, {invalid_argument,Prog,int, 10}},
-        parse_opts("10", [#{name => int, type => {int, [{min, 20}]}}])),
-    ?assertException(error, {argparse, {invalid_argument,Prog,int, -5}},
-        parse_opts("-5", [#{name => int, type => {int, [{max, -10}]}}])),
+    MinInt = #{name => int, type => {integer, [{min, 20}]}},
+    ?assertEqual({error, {Prog, MinInt, "10", <<"is less than accepted minimum">>}},
+        parse_opts("10", [MinInt])),
+    MaxInt = #{name => int, type => {integer, [{max, -10}]}},
+    ?assertEqual({error, {Prog, MaxInt, "-5", <<"is greater than accepted maximum">>}},
+        parse_opts("-5", [MaxInt])),
     %% string: regex & regex with options
     %% {string, string()} | {string, string(), []}
-    ?assertException(error, {argparse, {invalid_argument,Prog,str, "me"}},
-        parse_opts("me", [#{name => str, type => {string, "me.me"}}])),
-    ?assertException(error, {argparse, {invalid_argument,Prog,str, "me"}},
-        parse_opts("me", [#{name => str, type => {string, "me.me", []}}])),
+    StrRegex = #{name => str, type => {string, "me.me"}},
+    ?assertEqual({error, {Prog, StrRegex, "me", <<"does not match">>}},
+        parse_opts("me", [StrRegex])),
+    StrRegexOpt = #{name => str, type => {string, "me.me", []}},
+    ?assertEqual({error, {Prog, StrRegexOpt, "me", <<"does not match">>}},
+        parse_opts("me", [StrRegexOpt])),
     %% {binary, {re, binary()} | {re, binary(), []}
-    ?assertException(error, {argparse, {invalid_argument,Prog, bin, "me"}},
-        parse_opts("me", [#{name => bin, type => {binary, <<"me.me">>}}])),
-    ?assertException(error, {argparse, {invalid_argument,Prog,bin, "me"}},
-        parse_opts("me", [#{name => bin, type => {binary, <<"me.me">>, []}}])),
-    %% now successful regexes
-    ?assertEqual(#{str => "me"},
-        parse_opts("me", [#{name => str, type => {string, "m."}}])),
-    ?assertEqual(#{str => "me"},
-        parse_opts("me", [#{name => str, type => {string, "m.", []}}])),
-    ?assertEqual(#{str => "me"},
-        parse_opts("me", [#{name => str, type => {string, "m.", [{capture, none}]}}])),
-    %% and for binary too...
-    ?assertEqual(#{bin => <<"me">>},
-        parse_opts("me", [#{name => bin, type => {binary, <<"m.">>}}])),
-    ?assertEqual(#{bin => <<"me">>},
-        parse_opts("me", [#{name => bin, type => {binary, <<"m.">>, []}}])),
-    ?assertEqual(#{bin => <<"me">>},
-        parse_opts("me", [#{name => bin, type => {binary, <<"m.">>, [{capture, none}]}}])),
-    %% more successes
-    ?assertEqual(#{int => 5},
-        parse_opts("5", [#{name => int, type => {int, [{min, 0}, {max, 10}]}}])),
-    ?assertEqual(#{bin => <<"5">>},
-        parse_opts("5", [#{name => bin, type => binary}])),
-    ?assertEqual(#{str => "011"},
-        parse_opts("11", [#{name => str, type => {custom, fun(S) -> [$0|S] end}}])),
-    %% %% funny non-atom-atom: ensure the atom does not exist
-    ?assertException(error, badarg, list_to_existing_atom("$can_never_be")),
-    ArgMap = parse_opts("$can_never_be", [#{name => atom, type => {atom, unsafe}}]),
-    argparse:validate(#{arguments => [#{name => atom, type => {atom, unsafe}}]}),
-    %% must be successful, but really we can't create an atom in code!
-    ?assertEqual(list_to_existing_atom("$can_never_be"), maps:get(atom, ArgMap)),
-    %% choices: exceptions
-    ?assertException(error, {argparse, {invalid_argument, Prog, bin, "K"}},
-        parse_opts("K", [#{name => bin, type => {binary, [<<"M">>, <<"N">>]}}])),
-    ?assertException(error, {argparse, {invalid_argument, Prog, str, "K"}},
-        parse_opts("K", [#{name => str, type => {string, ["M", "N"]}}])),
-    ?assertException(error, {argparse, {invalid_argument, Prog, atom, "K"}},
-        parse_opts("K", [#{name => atom, type => {atom, [one, two]}}])),
-    ?assertException(error, {argparse, {invalid_argument, Prog, int, 12}},
-        parse_opts("12", [#{name => int, type => {int, [10, 11]}}])),
-    ?assertException(error, {argparse, {invalid_argument, Prog, float, 1.3}},
-        parse_opts("1.3", [#{name => float, type => {float, [1.2, 1.4]}}])),
-    %% choices: valid
-    ?assertEqual(#{bin => <<"K">>},
-        parse_opts("K", [#{name => bin, type => {binary, [<<"M">>, <<"K">>]}}])),
-    ?assertEqual(#{str => "K"},
-        parse_opts("K", [#{name => str, type => {string, ["K", "N"]}}])),
-    ?assertEqual(#{atom => one},
-        parse_opts("one", [#{name => atom, type => {atom, [one, two]}}])),
-    ?assertEqual(#{int => 12},
-        parse_opts("12", [#{name => int, type => {int, [10, 12]}}])),
-    ?assertEqual(#{float => 1.3},
-        parse_opts("1.3", [#{name => float, type => {float, [1.3, 1.4]}}])),
-    ok.
+    BinRegex = #{name => bin, type => {binary, <<"me.me">>}},
+    ?assertEqual({error, {Prog, BinRegex, "me", <<"does not match">>}},
+        parse_opts("me", [BinRegex])),
+    BinRegexOpt = #{name => bin, type => {binary, <<"me.me">>, []}},
+    ?assertEqual({error, {Prog, BinRegexOpt, "me", <<"does not match">>}},
+        parse_opts("me", [BinRegexOpt])),
+    %% invalid integer (comma , is not parsed)
+    ?assertEqual({error, {Prog, MinInt, "1,", <<"is not an integer">>}},
+        parse_opts(["1,"], [MinInt])),
+    %% test invalid choices
+    BinChoices = #{name => bin, type => {binary, [<<"M">>, <<"N">>]}},
+    ?assertEqual({error, {Prog, BinChoices, "K", <<"is not one of the choices">>}},
+        parse_opts("K", [BinChoices])),
+    StrChoices = #{name => str, type => {string, ["M", "N"]}},
+    ?assertEqual({error, {Prog, StrChoices, "K", <<"is not one of the choices">>}},
+        parse_opts("K", [StrChoices])),
+    AtomChoices = #{name => atom, type => {atom, [one, two]}},
+    ?assertEqual({error, {Prog, AtomChoices, "K", <<"is not one of the choices">>}},
+        parse_opts("K", [AtomChoices])),
+    IntChoices = #{name => int, type => {integer, [10, 11]}},
+    ?assertEqual({error, {Prog, IntChoices, "12", <<"is not one of the choices">>}},
+        parse_opts("12", [IntChoices])),
+    FloatChoices = #{name => float, type => {float, [1.2, 1.4]}},
+    ?assertEqual({error, {Prog, FloatChoices, "1.3", <<"is not one of the choices">>}},
+        parse_opts("1.3", [FloatChoices])),
+    %% unsuccessful user-defined conversion
+    ?assertMatch({error, {Prog, _, "REV", <<"failed faildation">>}},
+        parse_opts("REV", [#{name => user, type => {custom, fun (Str) -> integer_to_binary(Str) end}}])).
 
 complex_command() ->
     [{doc, "Parses a complex command that has a mix of optional and positional arguments"}].
@@ -317,229 +376,215 @@ complex_command(Config) when is_list(Config) ->
         #{name => boolean, type => boolean, short => $b, action => append, help => "Boolean list option"},
         #{name => float, type => float, short => $f, long => "-float", action => append, help => "Float option"},
         %% positional args
-        #{name => integer, type => int, help => "Integer variable"},
+        #{name => integer, type => integer, help => "Integer variable"},
         #{name => string, help => "alias for string option", action => extend, nargs => list}
     ]},
     CmdMap = #{commands => #{"start" => Command}},
     Parsed = argparse:parse(string:lexemes("start --float 1.04 -f 112 -b -b -s s1 42 --string s2 s3 s4", " "), CmdMap),
     Expected = #{float => [1.04, 112], boolean => [true, true], integer => 42, string => ["s1", "s2", "s3", "s4"]},
-    ?assertEqual({Expected, {["start"], Command}}, Parsed).
+    ?assertEqual({ok, Expected, [prog(), "start"], Command}, Parsed).
 
 unicode() ->
-    [{doc, "Ensure unicode support"}].
+    [{doc, "Tests basic unicode support"}].
 
 unicode(Config) when is_list(Config) ->
     %% test unicode short & long
-    ?assertEqual(#{one => true}, parse(["-Ф"], #{arguments => [#{name => one, short => $Ф, type => boolean}]})),
-    ?assertEqual(#{long => true}, parse(["--åäö"], #{arguments => [#{name => long, long => "-åäö", type => boolean}]})),
+    ?assertMatch({ok, #{one := true}, _, _},
+        parse(["-Ф"], #{arguments => [#{name => one, short => $Ф, type => boolean}]})),
+    ?assertMatch({ok, #{long := true}, _, _},
+        parse(["--åäö"], #{arguments => [#{name => long, long => "-åäö", type => boolean}]})),
     %% test default, help and value in unicode
     Cmd = #{arguments => [#{name => text, type => binary, help => "åäö", default => <<"★"/utf8>>}]},
     Expected = #{text => <<"★"/utf8>>},
-    ?assertEqual(Expected, argparse:parse([], Cmd)), %% default
-    ?assertEqual(Expected, argparse:parse(["★"], Cmd)), %% specified in the command line
-    ?assertEqual("usage: erl <text>\n\nArguments:\n  text åäö (binary, ★)\n", argparse:help(Cmd)),
+    Prog = [prog()],
+    ?assertEqual({ok, Expected, Prog, Cmd}, argparse:parse([], Cmd)), %% default
+    ?assertEqual({ok, Expected, Prog, Cmd}, argparse:parse(["★"], Cmd)), %% specified in the command line
+    ?assertEqual("Usage:\n  " ++ prog() ++ " <text>\n\nArguments:\n  text åäö (binary, ★)\n",
+        unicode:characters_to_list(argparse:help(Cmd))),
     %% test command name and argument name in unicode
     Uni = #{commands => #{"åäö" => #{help => "öФ"}}, handler => optional,
         arguments => [#{name => "Ф", short => $ä, long => "åäö"}]},
-    UniExpected = "usage: erl  {åäö} [-ä <Ф>] [-åäö <Ф>]\n\nSubcommands:\n  åäö      öФ\n\nOptional arguments:\n  -ä, -åäö Ф\n",
-    ?assertEqual(UniExpected, argparse:help(Uni)),
+    UniExpected = "Usage:\n  " ++ prog() ++
+        " {åäö} [-ä <Ф>] [-åäö <Ф>]\n\nSubcommands:\n  åäö      öФ\n\nOptional arguments:\n  -ä, -åäö Ф\n",
+    ?assertEqual(UniExpected, unicode:characters_to_list(argparse:help(Uni))),
     ParsedExpected = #{"Ф" => "öФ"},
-    ?assertEqual(ParsedExpected, argparse:parse(["-ä", "öФ"], Uni)).
+    ?assertEqual({ok, ParsedExpected, Prog, Uni}, argparse:parse(["-ä", "öФ"], Uni)).
 
-errors() ->
-    [{doc, "Tests for various errors, missing arguments etc"}].
+parser_error() ->
+    [{doc, "Tests error tuples that the parser returns"}].
 
-errors(Config) when is_list(Config) ->
-    Prog = [prog()],
-    %% conflicting option names
-    ?assertException(error, {argparse, {invalid_option, _, two, short, "short conflicting with one"}},
-        parse("", #{arguments => [#{name => one, short => $$}, #{name => two, short => $$}]})),
-    ?assertException(error, {argparse, {invalid_option, _, two, long, "long conflicting with one"}},
-        parse("", #{arguments => [#{name => one, long => "a"}, #{name => two, long => "a"}]})),
-    %% broken options
-    %% long must be a string
-    ?assertException(error, {argparse, {invalid_option, _, one, long, _}},
-        parse("", #{arguments => [#{name => one, long => ok}]})),
-    %% short must be a printable character
-    ?assertException(error, {argparse, {invalid_option, _, one, short, _}},
-        parse("", #{arguments => [#{name => one, short => ok}]})),
-    ?assertException(error, {argparse, {invalid_option, _, one, short, _}},
-        parse("", #{arguments => [#{name => one, short => 7}]})),
-    %% required is a boolean
-    ?assertException(error, {argparse, {invalid_option, _, one, required, _}},
-        parse("", #{arguments => [#{name => one, required => ok}]})),
-    ?assertException(error, {argparse, {invalid_option, _, one, help, _}},
-        parse("", #{arguments => [#{name => one, help => ok}]})),
-    %% broken commands
-    ?assertException(error, {argparse, {invalid_command, _, commands, _}},
-        parse("", #{commands => ok})),
-    ?assertException(error, {argparse, {invalid_command, _, commands, _}},
-        parse("", #{commands => #{ok => #{}}})),
-    ?assertException(error, {argparse, {invalid_command, _, help, _}},
-        parse("", #{commands => #{"ok" => #{help => ok}}})),
-    ?assertException(error, {argparse, {invalid_command, _, handler, _}},
-        parse("", #{commands => #{"ok" => #{handler => fun errors/0}}})),
+parser_error(Config) when is_list(Config) ->
+    Prog = prog(),
     %% unknown option at the top of the path
-    ?assertException(error, {argparse, {unknown_argument, Prog, "arg"}},
+    ?assertEqual({error, {[Prog], undefined, "arg", <<>>}},
         parse_cmd(["arg"], #{})),
-    %% positional argument missing
+    %% positional argument missing in a sub-command
     Opt = #{name => mode, required => true},
-    ?assertException(error, {argparse, {missing_argument, _, mode}},
+    ?assertMatch({error, {[Prog, "start"], _, undefined, <<>>}},
         parse_cmd(["start"], #{"start" => #{arguments => [Opt]}})),
-    %% optional argument missing
+    %% optional argument missing in a sub-command
     Opt1 = #{name => mode, short => $o, required => true},
-    ?assertException(error, {argparse, {missing_argument, _, mode}},
+    ?assertMatch({error, {[Prog, "start"], _, undefined, <<>>}},
         parse_cmd(["start"], #{"start" => #{arguments => [Opt1]}})),
-    %% atom that does not exist
+    %% positional argument: an atom that does not exist
     Opt2 = #{name => atom, type => atom},
-    ?assertException(error, {argparse, {invalid_argument, _, atom, "boo-foo"}},
-        parse_cmd(["start boo-foo"], #{"start" => #{arguments => [Opt2]}})),
+    ?assertEqual({error, {[Prog], Opt2, "boo-foo", <<"is not an existing atom">>}},
+        parse_opts(["boo-foo"], [Opt2])),
     %% optional argument missing some items
     Opt3 = #{name => kernel, long => "kernel", type => atom, nargs => 2},
-    ?assertException(error, {argparse, {invalid_argument, _, kernel, ["port"]}},
-        parse_cmd(["start -kernel port"], #{"start" => #{arguments => [Opt3]}})),
-    %% not-a-list of arguments
-    ?assertException(error, {argparse, {invalid_command, _, commands,"options must be a list"}},
-        parse_cmd([], #{"start" => #{arguments => atom}})),
-    %% command is not a map
-    ?assertException(error, {argparse, {invalid_command, _, commands,"command description must be a map"}},
-        parse_cmd([], #{"start" => []})),
+    ?assertEqual({error, {[Prog], Opt3, ["port"], "expected 2, found 1 argument(s)"}},
+        parse_opts(["-kernel port"], [Opt3])),
     %% positional argument missing some items
-    Opt4 = #{name => arg, type => atom, nargs => 2},
-    ?assertException(error, {argparse, {invalid_argument, _, arg, ["p1"]}},
-    parse_cmd(["start p1"], #{"start" => #{arguments => [Opt4]}})).
+    Opt4 = #{name => arg, type => atom, nargs => 3},
+    ?assertEqual({error, {[Prog], Opt4, ["p1"], "expected 3, found 1 argument(s)"}},
+        parse_opts(["p1"], [Opt4])),
+    %% short option with no argument, when it's needed
+    ?assertMatch({error, {_, _, undefined, <<"expected argument">>}},
+        parse("-1", #{arguments => [#{name => short49, short => 49}]})).
 
-args() ->
+nargs() ->
     [{doc, "Tests argument consumption option, with nargs"}].
 
-args(Config) when is_list(Config) ->
+nargs(Config) when is_list(Config) ->
+    Prog = [prog()],
     %% consume optional list arguments
     Opts = [
-        #{name => arg, short => $s, nargs => list, type => int},
+        #{name => arg, short => $s, nargs => list, type => integer},
         #{name => bool, short => $b, type => boolean}
     ],
-    ?assertEqual(#{arg => [1, 2, 3], bool => true},
+    ?assertMatch({ok, #{arg := [1, 2, 3], bool := true}, _, _},
         parse_opts(["-s 1 2 3 -b"], Opts)),
     %% consume one_or_more arguments in an optional list
     Opts2 = [
         #{name => arg, short => $s, nargs => nonempty_list},
         #{name => extra, short => $x}
         ],
-    ?assertEqual(#{extra => "X", arg => ["a","b","c"]},
+    ?assertMatch({ok, #{extra := "X", arg := ["a","b","c"]}, _, _},
         parse_opts(["-s port -s a b c -x X"], Opts2)),
     %% error if there is no argument to consume
-    ?assertException(error, {argparse, {invalid_argument, _, arg, ["-x"]}},
+    ?assertMatch({error, {_, _, ["-x"], <<"expected argument">>}},
         parse_opts(["-s -x"], Opts2)),
     %% error when positional has nargs = nonempty_list or pos_integer
-    ?assertException(error, {argparse, {missing_argument, _, req}},
+    ?assertMatch({error, {_, _, undefined, <<>>}},
         parse_opts([""], [#{name => req, nargs => nonempty_list}])),
     %% positional arguments consumption: one or more positional argument
-    OptsPos1 = [
+    OptsPos1 = #{arguments => [
         #{name => arg, nargs => nonempty_list},
         #{name => extra, short => $x}
-    ],
-    ?assertEqual(#{extra => "X", arg => ["b","c"]},
-        parse_opts(["-x port -x a b c -x X"], OptsPos1)),
+    ]},
+    ?assertEqual({ok, #{extra => "X", arg => ["b","c"]}, Prog, OptsPos1},
+        parse(["-x port -x a b c -x X"], OptsPos1)),
     %% positional arguments consumption, any number (maybe zero)
     OptsPos2 = #{arguments => [
         #{name => arg, nargs => list},
         #{name => extra, short => $x}
     ]},
-    ?assertEqual(#{extra => "X", arg => ["a","b","c"]}, parse(["-x port a b c -x X"], OptsPos2)),
+    ?assertEqual({ok, #{extra => "X", arg => ["a","b","c"]}, Prog, OptsPos2},
+        parse(["-x port a b c -x X"], OptsPos2)),
     %% positional: consume ALL arguments!
-    OptsAll = [
+    OptsAll = #{arguments => [
         #{name => arg, nargs => all},
         #{name => extra, short => $x}
-    ],
-    ?assertEqual(#{extra => "port", arg => ["a","b","c", "-x", "X"]},
-        parse_opts(["-x port a b c -x X"], OptsAll)),
-    %%
+    ]},
+    ?assertEqual({ok, #{extra => "port", arg => ["a","b","c", "-x", "X"]}, Prog, OptsAll},
+        parse(["-x port a b c -x X"], OptsAll)),
+    %% maybe with a specified default
     OptMaybe = [
         #{name => foo, long => "-foo", nargs => {'maybe', c}, default => d},
         #{name => bar, nargs => 'maybe', default => d}
     ],
-    ?assertEqual(#{foo => "YY", bar => "XX"},
+    ?assertMatch({ok, #{foo := "YY", bar := "XX"}, Prog, _},
         parse_opts(["XX --foo YY"], OptMaybe)),
-    ?assertEqual(#{foo => c, bar => "XX"},
+    ?assertMatch({ok, #{foo := c, bar := "XX"}, Prog, _},
         parse_opts(["XX --foo"], OptMaybe)),
-    ?assertEqual(#{foo => d, bar => d},
+    ?assertMatch({ok, #{foo := d, bar := d}, Prog, _},
         parse_opts([""], OptMaybe)),
-    %% maybe with default
-    ?assertEqual(#{foo => d, bar => "XX", baz => ok},
+    %% maybe with default provided by argparse
+    ?assertMatch({ok, #{foo := d, bar := "XX", baz := ok}, _, _},
         parse_opts(["XX -b"], [#{name => baz, nargs => 'maybe', short => $b, default => ok} | OptMaybe])),
     %% maybe arg - with no default given
-    ?assertEqual(#{foo => d, bar => "XX", baz => 0},
-        parse_opts(["XX -b"], [#{name => baz, nargs => 'maybe', short => $b, type => int} | OptMaybe])),
-    ?assertEqual(#{foo => d, bar => "XX", baz => ""},
+    ?assertMatch({ok, #{foo := d, bar := "XX", baz := 0}, _, _},
+        parse_opts(["XX -b"], [#{name => baz, nargs => 'maybe', short => $b, type => integer} | OptMaybe])),
+    ?assertMatch({ok, #{foo := d, bar := "XX", baz := ""}, _, _},
         parse_opts(["XX -b"], [#{name => baz, nargs => 'maybe', short => $b, type => string} | OptMaybe])),
-    ?assertEqual(#{foo => d, bar => "XX", baz => undefined},
+    ?assertMatch({ok, #{foo := d, bar := "XX", baz := undefined}, _, _},
         parse_opts(["XX -b"], [#{name => baz, nargs => 'maybe', short => $b, type => atom} | OptMaybe])),
-    ?assertEqual(#{foo => d, bar => "XX", baz => <<"">>},
+    ?assertMatch({ok, #{foo := d, bar := "XX", baz := <<"">>}, _, _},
         parse_opts(["XX -b"], [#{name => baz, nargs => 'maybe', short => $b, type => binary} | OptMaybe])),
     %% nargs: optional list, yet it still needs to be 'not required'!
-    OptList = [#{name => arg, nargs => list, required => false, type => int}],
-    ?assertEqual(#{}, parse_opts("", OptList)),
-    ok.
+    OptList = [#{name => arg, nargs => list, required => false, type => integer}],
+    ?assertEqual({ok, #{}, Prog, #{arguments => OptList}}, parse_opts("", OptList)),
+    %% tests that action "count" with nargs "maybe" counts two times, first time
+    %% consuming an argument (for "maybe"), second time just counting
+    Cmd = #{arguments => [
+        #{name => short49, short => $1, long => "-force", action => count, nargs => 'maybe'}]},
+    ?assertEqual({ok, #{short49 => 2}, Prog, Cmd},
+        parse("-1 arg1 --force", Cmd)).
 
 argparse() ->
-    [{doc, "Tests examples from argparse Python library"}].
+    [{doc, "Tests success cases, inspired by argparse in Python"}].
 
 argparse(Config) when is_list(Config) ->
+    Prog = [prog()],
     Parser = #{arguments => [
         #{name => sum, long => "-sum", action => {store, sum}, default => max},
-        #{name => integers, type => int, nargs => nonempty_list}
+        #{name => integers, type => integer, nargs => nonempty_list}
         ]},
-    ?assertEqual(#{integers => [1, 2, 3, 4], sum => max}, parse("1 2 3 4", Parser)),
-    ?assertEqual(#{integers => [1, 2, 3, 4], sum => sum}, parse("1 2 3 4 --sum", Parser)),
-    ?assertEqual(#{integers => [7, -1, 42], sum => sum}, parse("--sum 7 -1 42", Parser)),
+    ?assertEqual({ok, #{integers => [1, 2, 3, 4], sum => max}, Prog, Parser},
+        parse("1 2 3 4", Parser)),
+    ?assertEqual({ok, #{integers => [1, 2, 3, 4], sum => sum}, Prog, Parser},
+        parse("1 2 3 4 --sum", Parser)),
+    ?assertEqual({ok, #{integers => [7, -1, 42], sum => sum}, Prog, Parser},
+        parse("--sum 7 -1 42", Parser)),
     %% name or flags
     Parser2 = #{arguments => [
         #{name => bar, required => true},
         #{name => foo, short => $f, long => "-foo"}
     ]},
-    ?assertEqual(#{bar => "BAR"}, parse("BAR", Parser2)),
-    ?assertEqual(#{bar => "BAR", foo => "FOO"}, parse("BAR --foo FOO", Parser2)),
+    ?assertEqual({ok, #{bar => "BAR"}, Prog, Parser2}, parse("BAR", Parser2)),
+    ?assertEqual({ok, #{bar => "BAR", foo => "FOO"}, Prog, Parser2}, parse("BAR --foo FOO", Parser2)),
     %PROG: error: the following arguments are required: bar
-    ?assertException(error, {argparse, {missing_argument, _, bar}}, parse("--foo FOO", Parser2)),
+    ?assertMatch({error, {Prog, _, undefined, <<>>}}, parse("--foo FOO", Parser2)),
     %% action tests: default
-    ?assertEqual(#{foo => "1"},
+    ?assertMatch({ok, #{foo := "1"}, Prog, _},
         parse("--foo 1", #{arguments => [#{name => foo, long => "-foo"}]})),
     %% action test: store
-    ?assertEqual(#{foo => 42},
+    ?assertMatch({ok, #{foo := 42}, Prog, _},
         parse("--foo", #{arguments => [#{name => foo, long => "-foo", action => {store, 42}}]})),
     %% action tests: boolean (variants)
-    ?assertEqual(#{foo => true},
+    ?assertMatch({ok, #{foo := true}, Prog, _},
         parse("--foo", #{arguments => [#{name => foo, long => "-foo", action => {store, true}}]})),
-    ?assertEqual(#{foo => true},
+    ?assertMatch({ok, #{foo := 42}, Prog, _},
+        parse("--foo", #{arguments => [#{name => foo, long => "-foo", type => boolean, action => {store, 42}}]})),
+    ?assertMatch({ok, #{foo := true}, Prog, _},
         parse("--foo", #{arguments => [#{name => foo, long => "-foo", type => boolean}]})),
-    ?assertEqual(#{foo => true},
+    ?assertMatch({ok, #{foo := true}, Prog, _},
         parse("--foo true", #{arguments => [#{name => foo, long => "-foo", type => boolean}]})),
-    ?assertEqual(#{foo => false},
+    ?assertMatch({ok, #{foo := false}, Prog, _},
         parse("--foo false", #{arguments => [#{name => foo, long => "-foo", type => boolean}]})),
     %% action tests: append & append_const
-    ?assertEqual(#{all => [1, "1"]},
+    ?assertMatch({ok, #{all := [1, "1"]}, Prog, _},
         parse("--x 1 -x 1", #{arguments => [
-            #{name => all, long => "-x", type => int, action => append},
+            #{name => all, long => "-x", type => integer, action => append},
             #{name => all, short => $x, action => append}]})),
-    ?assertEqual(#{all => ["Z", 2]},
+    ?assertMatch({ok, #{all := ["Z", 2]}, Prog, _},
         parse("--x -x", #{arguments => [
             #{name => all, long => "-x", action => {append, "Z"}},
             #{name => all, short => $x, action => {append, 2}}]})),
     %% count:
-    ?assertEqual(#{v => 3},
-        parse("-v -v -v", #{arguments => [#{name => v, short => $v, action => count}]})),
-    ok.
+    ?assertMatch({ok, #{v := 3}, Prog, _},
+        parse("-v -v -v", #{arguments => [#{name => v, short => $v, action => count}]})).
 
 negative() ->
     [{doc, "Test negative number parser"}].
 
 negative(Config) when is_list(Config) ->
     Parser = #{arguments => [
-        #{name => x, short => $x, type => int, action => store},
+        #{name => x, short => $x, type => integer, action => store},
         #{name => foo, nargs => 'maybe', required => false}
     ]},
-    ?assertEqual(#{x => -1}, parse("-x -1", Parser)),
-    ?assertEqual(#{x => -1, foo => "-5"}, parse("-x -1 -5", Parser)),
+    ?assertMatch({ok, #{x := -1}, _, _}, parse("-x -1", Parser)),
+    ?assertMatch({ok, #{x := -1, foo := "-5"}, _, _}, parse("-x -1 -5", Parser)),
     %%
     Parser2 = #{arguments => [
         #{name => one, short => $1},
@@ -547,19 +592,19 @@ negative(Config) when is_list(Config) ->
     ]},
 
     %% negative number options present, so -1 is an option
-    ?assertEqual(#{one => "X"}, parse("-1 X", Parser2)),
+    ?assertMatch({ok, #{one := "X"}, _, _}, parse("-1 X", Parser2)),
     %% negative number options present, so -2 is an option
-    ?assertException(error, {argparse, {unknown_argument, _, "-2"}}, parse("-2", Parser2)),
+    ?assertMatch({error, {_, undefined, "-2", _}}, parse("-2", Parser2)),
 
     %% negative number options present, so both -1s are options
-    ?assertException(error, {argparse, {missing_argument,_,one}}, parse("-1 -1", Parser2)),
+    ?assertMatch({error, {_, _, undefined, _}}, parse("-1 -1", Parser2)),
     %% no "-" prefix, can only be an integer
-    ?assertEqual(#{foo => "-1"}, argparse:parse(["-1"], Parser2, #{prefixes => "+"})),
+    ?assertMatch({ok, #{foo := "-1"}, _, _}, argparse:parse(["-1"], Parser2, #{prefixes => "+"})),
     %% no "-" prefix, can only be an integer, but just one integer!
-    ?assertException(error, {argparse, {unknown_argument, _, "-1"}},
+    ?assertMatch({error, {_, undefined, "-1", _}},
         argparse:parse(["-2", "-1"], Parser2, #{prefixes => "+"})),
     %% just in case, floats work that way too...
-    ?assertException(error, {argparse, {unknown_argument, _, "-2"}},
+    ?assertMatch({error, {_, undefined, "-2", _}},
         parse("-2", #{arguments => [#{name => one, long => "1.2"}]})).
 
 nodigits() ->
@@ -572,37 +617,37 @@ nodigits(Config) when is_list(Config) ->
         #{name => arg, nargs => list}
     ]},
     %% ensure not to consume optional prefix
-    ?assertEqual(#{extra => "X", arg => ["a","b","3"]},
+    ?assertEqual({ok, #{extra => "X", arg => ["a","b","3"]}, [prog()], Parser3},
         argparse:parse(string:lexemes("-3 port a b 3 +3 X", " "), Parser3, #{prefixes => "-+"})).
-    %% verify split_to_option working with weird prefix
-    %?assertEqual(#{extra => "X", arg => ["a","b","-3"]},
-    %    argparse:parse(string:lexemes("-3 port a b -3 -3 X", " "), Parser3, #{prefixes => "-+"})).
 
-python_issue_15112() ->
-    [{doc, "Tests for https://bugs.python.org/issue15112"}].
+pos_mixed_with_opt() ->
+    [{doc, "Tests that optional argument correctly consumes expected argument"
+        "inspired by https://github.com/python/cpython/issues/59317"}].
 
-python_issue_15112(Config) when is_list(Config) ->
+pos_mixed_with_opt(Config) when is_list(Config) ->
     Parser = #{arguments => [
         #{name => pos},
-        #{name => foo},
-        #{name => spam, default => 24, type => int, long => "-spam"},
+        #{name => opt, default => 24, type => integer, long => "-opt"},
         #{name => vars, nargs => list}
     ]},
-    ?assertEqual(#{pos => "1", foo => "2", spam => 8, vars => ["8", "9"]},
-        parse("1 2 --spam 8 8 9", Parser)).
+    ?assertEqual({ok, #{pos => "1", opt => 8, vars => ["8", "9"]}, [prog()], Parser},
+        parse("1 2 --opt 8 8 9", Parser)).
 
 default_for_not_required() ->
     [{doc, "Tests that default value is used for non-required positional argument"}].
 
 default_for_not_required(Config) when is_list(Config) ->
-    ?assertEqual(#{def => 1}, parse("", #{arguments => [#{name => def, short => $d, required => false, default => 1}]})),
-    ?assertEqual(#{def => 1}, parse("", #{arguments => [#{name => def, required => false, default => 1}]})).
+    ?assertMatch({ok, #{def := 1}, _, _},
+        parse("", #{arguments => [#{name => def, short => $d, required => false, default => 1}]})),
+    ?assertMatch({ok, #{def := 1}, _, _},
+        parse("", #{arguments => [#{name => def, required => false, default => 1}]})).
 
 global_default() ->
     [{doc, "Tests that a global default can be enabled for all non-required arguments"}].
 
 global_default(Config) when is_list(Config) ->
-    ?assertEqual(#{def => "global"}, argparse:parse("", #{arguments => [#{name => def, type => int, required => false}]},
+    ?assertMatch({ok, #{def := "global"}, _, _},
+        argparse:parse("", #{arguments => [#{name => def, type => integer, required => false}]},
         #{default => "global"})).
 
 subcommand() ->
@@ -616,56 +661,17 @@ subcommand(Config) when is_list(Config) ->
             arguments => [#{name => foo, type => boolean, long => "-foo"}, #{name => baz}],
             commands => #{
                 "two" => TwoCmd}}}},
-    ?assertEqual(
-        {#{force => true, baz => "N1O1O", foo => true, bar => "bar"}, {["one", "two"], TwoCmd}},
+    ?assertEqual({ok, #{force => true, baz => "N1O1O", foo => true, bar => "bar"}, [prog(), "one", "two"], TwoCmd},
         parse("one N1O1O -f two --foo bar", Cmd)),
     %% it is an error not to choose subcommand
-    ?assertException(error, {argparse, {missing_argument,_,"missing handler"}},
+    ?assertEqual({error, {[prog(), "one"], undefined, undefined, <<"subcommand expected">>}},
         parse("one N1O1O -f", Cmd)).
-
-error_format() ->
-    [{doc, "Tests error output formatter"}].
-
-error_format(Config) when is_list(Config) ->
-    %% does not really require testing, but serve well as contract,
-    %%  and good for coverage
-    {ok, [[Prog]]} = init:get_argument(progname),
-    ?assertEqual(Prog ++ ": internal error, invalid field 'commands': sub-commands must be a map\n",
-        make_error([""], #{commands => []})),
-    ?assertEqual(Prog ++ " one: internal error, invalid field 'commands': sub-commands must be a map\n",
-        make_error([""], #{commands => #{"one" => #{commands => []}}})),
-    ?assertEqual(Prog ++ " one two: internal error, invalid field 'commands': sub-commands must be a map\n",
-        make_error([""], #{commands => #{"one" => #{commands => #{"two" => #{commands => []}}}}})),
-        %%
-    ?assertEqual(Prog ++ ": internal error, option  field 'name': argument must be a map, and specify 'name'\n",
-        make_error([""], #{arguments => [#{}]})),
-    %%
-    ?assertEqual(Prog ++ ": internal error, option name field 'type': unsupported\n",
-        make_error([""], #{arguments => [#{name => name, type => foo}]})),
-    ?assertEqual(Prog ++ ": internal error, option name field 'nargs': unsupported\n",
-        make_error([""], #{arguments => [#{name => name, nargs => foo}]})),
-    ?assertEqual(Prog ++ ": internal error, option name field 'action': unsupported\n",
-        make_error([""], #{arguments => [#{name => name, action => foo}]})),
-    %% unknown arguments
-    ?assertEqual(Prog ++ ": unrecognised argument: arg\n", make_error(["arg"], #{})),
-    ?assertEqual(Prog ++ ": unrecognised argument: -a\n", make_error(["-a"], #{})),
-    %% missing argument
-    ?assertEqual(Prog ++ ": required argument missing: need\n", make_error([""],
-        #{arguments => [#{name => need}]})),
-    ?assertEqual(Prog ++ ": required argument missing: need\n", make_error([""],
-        #{arguments => [#{name => need, short => $n, required => true}]})),
-    %% invalid value
-    ?assertEqual(Prog ++ ": invalid argument foo for: need\n", make_error(["foo"],
-        #{arguments => [#{name => need, type => int}]})),
-    ?assertEqual(Prog ++ ": invalid argument cAnNotExIsT for: need\n", make_error(["cAnNotExIsT"],
-        #{arguments => [#{name => need, type => atom}]})),
-    ok.
 
 very_short() ->
     [{doc, "Tests short option appended to the optional itself"}].
 
 very_short(Config) when is_list(Config) ->
-    ?assertEqual(#{x => "V"},
+    ?assertMatch({ok, #{x := "V"}, _, _},
         parse("-xV", #{arguments => [#{name => x, short => $x}]})).
 
 multi_short() ->
@@ -673,13 +679,13 @@ multi_short() ->
 
 multi_short(Config) when is_list(Config) ->
     %% ensure non-flammable argument does not explode, even when it's possible
-    ?assertEqual(#{v => "xv"},
+    ?assertMatch({ok, #{v := "xv"}, _, _},
         parse("-vxv", #{arguments => [#{name => v, short => $v}, #{name => x, short => $x}]})),
     %% ensure 'verbosity' use-case works
-    ?assertEqual(#{v => 3},
+    ?assertMatch({ok, #{v := 3}, _, _},
         parse("-vvv", #{arguments => [#{name => v, short => $v, action => count}]})),
     %%
-    ?assertEqual(#{recursive => true, force => true, path => "dir"},
+    ?assertMatch({ok, #{recursive := true, force := true, path := "dir"}, _, _},
         parse("-rf dir", #{arguments => [
             #{name => recursive, short => $r, type => boolean},
             #{name => force, short => $f, type => boolean},
@@ -716,41 +722,83 @@ proxy_arguments(Config) when is_list(Config) ->
         ],
         handler => fun (#{}) -> ok end
     },
-    ?assertEqual(#{node => "node1"}, parse("node1", Cmd)),
-    ?assertEqual({#{node => "node1"}, {["stop"], #{}}}, parse("node1 stop", Cmd)),
-    ?assertMatch({#{node := "node2.org", shell := true, skip := true}, _}, parse("node2.org start -x -s", Cmd)),
-    ?assertMatch({#{args := ["-app","key","value"],node := "node1.org"}, {["start"], _}},
+    Prog = prog(),
+    ?assertMatch({ok, #{node := "node1"}, _, _}, parse("node1", Cmd)),
+    ?assertMatch({ok, #{node := "node1"}, [Prog, "stop"], #{}}, parse("node1 stop", Cmd)),
+    ?assertMatch({ok, #{node := "node2.org", shell := true, skip := true}, _, _}, parse("node2.org start -x -s", Cmd)),
+    ?assertMatch({ok, #{args := ["-app","key","value"],node := "node1.org"}, [Prog, "start"], _},
         parse("node1.org start -app key value", Cmd)),
-    ?assertMatch({#{args := ["-app","key","value", "-app2", "key2", "value2"],node := "node3.org", shell := true}, {["start"], _}},
+    ?assertMatch({ok, #{args := ["-app","key","value", "-app2", "key2", "value2"],
+        node := "node3.org", shell := true}, [Prog, "start"], _},
         parse("node3.org start -s -app key value -app2 key2 value2", Cmd)),
     %% test that any non-required positionals are skipped
-    ?assertMatch({#{args := ["-a","bcd"], node := "node2.org", skip := "ok"}, _}, parse("node2.org status -a bcd", Cmd)),
-    ?assertMatch({#{args := ["-app", "key"], node := "node2.org"}, _}, parse("node2.org state -app key", Cmd)).
+    ?assertMatch({ok, #{args := ["-a","bcd"], node := "node2.org", skip := "ok"}, _, _}, parse("node2.org status -a bcd", Cmd)),
+    ?assertMatch({ok, #{args := ["-app", "key"], node := "node2.org"}, _, _}, parse("node2.org state -app key", Cmd)).
 
+%%--------------------------------------------------------------------
+%% Usage Test Cases
 
 usage() ->
     [{doc, "Basic tests for help formatter, including 'hidden' help"}].
 
 usage(Config) when is_list(Config) ->
     Cmd = ubiq_cmd(),
-    Usage = "usage: " ++ prog() ++ " start {crawler|doze} [-lrfv] [-s <shard>...] [-z <z>] [-m <more>] [-b <bin>] [-g <g>] [-t <t>] ---maybe-req -y <y>"
-        " --yyy <y> [-u <u>] [-c <choice>] [-q <fc>] [-w <ac>] [--unsafe <au>] [--safe <as>] [-foobar <long>] [--force] [-i <interval>] [--req <weird>] [--float <float>] <server> [<optpos>]"
-        "\n\nSubcommands:\n  crawler      controls crawler behaviour\n  doze         dozes a bit\n\nArguments:\n  server       server to start\n  optpos       optional positional (int)"
-        "\n\nOptional arguments:\n  -s           initial shards (int)\n  -z           between (1 <= int <= 10)\n  -l           maybe lower (int <= 10)"
-        "\n  -m           less than 10 (int <= 10)\n  -b           binary with re (binary re: m)\n  -g           binary with re (binary re: m)\n  -t           string with re (string re: m)"
-        "\n  ---maybe-req maybe required int (int)\n  -y, --yyy    string with re (string re: m)\n  -u           string choices (choice: 1, 2)\n  -c           tough choice (choice: 1, 2, 3)"
-        "\n  -q           floating choice (choice: 2.10000, 1.20000)\n  -w           atom choice (choice: one, two)\n  --unsafe     unsafe atom (atom)\n  --safe       safe atom (existing atom)"
-        "\n  -foobar      foobaring option\n  -r           recursive\n  -f, --force  force\n  -v           verbosity level"
-        "\n  -i           interval set (int >= 1)\n  --req        required optional, right?\n  --float      floating-point long form argument (float, 3.14)\n",
-    ?assertEqual(Usage, argparse:help(Cmd, #{command => ["start"]})),
-    FullCmd = "usage: " ++ prog() ++ " <command> [-rfv] [--force] [-i <interval>] [--req <weird>] [--float <float>]\n\nSubcommands:\n  start       verifies configuration and starts server"
-        "\n  status      prints server status\n  stop        stops running server\n\nOptional arguments:\n  -r          recursive\n  -f, --force force"
-        "\n  -v          verbosity level\n  -i          interval set (int >= 1)\n  --req       required optional, right?\n  --float     floating-point long form argument (float, 3.14)\n",
-    ?assertEqual(FullCmd, argparse:help(Cmd)),
-    CrawlerStatus = "usage: " ++ prog() ++ " status crawler [-rfv] [---extra <extra>] [--force] [-i <interval>] [--req <weird>] [--float <float>]\n\nOptional arguments:\n"
-        "  ---extra    extra option very deep\n  -r          recursive\n  -f, --force force\n  -v          verbosity level"
-        "\n  -i          interval set (int >= 1)\n  --req       required optional, right?\n  --float     floating-point long form argument (float, 3.14)\n",
-    ?assertEqual(CrawlerStatus, argparse:help(Cmd, #{command => ["status", "crawler"]})),
+    Usage = "Usage:\n  " ++ prog() ++ " start {crawler|doze} [-lrfv] [-s <shard>...] [-z <z>] [-m <more>] [-b <bin>]\n"
+        "      [-g <g>] [-t <t>] ---maybe-req -y <y> --yyy <y> [-u <u>] [-c <choice>]\n"
+        "      [-q <fc>] [-w <ac>] [--unsafe <au>] [--safe <as>] [-foobar <long>] [--force]\n"
+        "      [-i <interval>] [--req <weird>] [--float <float>] <server> [<optpos>]\n\n"
+        "Subcommands:\n"
+        "  crawler      controls crawler behaviour\n"
+        "  doze         dozes a bit\n\n"
+        "Arguments:\n"
+        "  server       server to start\n"
+        "  optpos       optional positional (int)\n\n"
+        "Optional arguments:\n"
+        "  -s           initial shards (int)\n"
+        "  -z           between (1 <= int <= 10)\n"
+        "  -l           maybe lower (int <= 10)\n"
+        "  -m           less than 10 (int <= 10)\n"
+        "  -b           binary with re (binary re: m)\n"
+        "  -g           binary with re (binary re: m)\n"
+        "  -t           string with re (string re: m)\n"
+        "  ---maybe-req maybe required int (int)\n"
+        "  -y, --yyy    string with re (string re: m)\n"
+        "  -u           string choices (choice: 1, 2)\n"
+        "  -c           tough choice (choice: 1, 2, 3)\n"
+        "  -q           floating choice (choice: 2.10000, 1.20000)\n"
+        "  -w           atom choice (choice: one, two)\n"
+        "  --unsafe     unsafe atom (atom)\n"
+        "  --safe       safe atom (existing atom)\n"
+        "  -foobar      foobaring option\n"
+        "  -r           recursive\n"
+        "  -f, --force  force\n"
+        "  -v           verbosity level\n"
+        "  -i           interval set (int >= 1)\n"
+        "  --req        required optional, right?\n"
+        "  --float      floating-point long form argument (float, 3.14)\n",
+    ?assertEqual(Usage, unicode:characters_to_list(argparse:help(Cmd, #{command => ["start"]}))),
+    FullCmd = "Usage:\n  " ++ prog() ++
+        " <command> [-rfv] [--force] [-i <interval>] [--req <weird>] [--float <float>]\n\n"
+        "Subcommands:\n"
+        "  start       verifies configuration and starts server\n"
+        "  status      prints server status\n"
+        "  stop        stops running server\n\n"
+        "Optional arguments:\n"
+        "  -r          recursive\n"
+        "  -f, --force force\n"
+        "  -v          verbosity level\n"
+        "  -i          interval set (int >= 1)\n"
+        "  --req       required optional, right?\n"
+        "  --float     floating-point long form argument (float, 3.14)\n",
+    ?assertEqual(FullCmd, unicode:characters_to_list(argparse:help(Cmd))),
+    CrawlerStatus = "Usage:\n  " ++ prog() ++ " status crawler [-rfv] [---extra <extra>] [--force] [-i <interval>]\n"
+        "      [--req <weird>] [--float <float>]\n\nOptional arguments:\n"
+        "  ---extra    extra option very deep\n  -r          recursive\n"
+        "  -f, --force force\n  -v          verbosity level\n"
+        "  -i          interval set (int >= 1)\n"
+        "  --req       required optional, right?\n"
+        "  --float     floating-point long form argument (float, 3.14)\n",
+    ?assertEqual(CrawlerStatus, unicode:characters_to_list(argparse:help(Cmd, #{command => ["status", "crawler"]}))),
     ok.
 
 usage_required_args() ->
@@ -758,40 +806,8 @@ usage_required_args() ->
 
 usage_required_args(Config) when is_list(Config) ->
     Cmd = #{commands => #{"test" => #{arguments => [#{name => required, required => true, long => "-req"}]}}},
-    Expected = "",
-    ?assertEqual(Expected, argparse:help(Cmd, #{command => ["test"]})).
-
-error_usage() ->
-    [{doc, "Test that usage information is added to errors"}].
-
-%% This test does not verify usage printed,
-%%  but at least ensures formatter does not crash.
-error_usage(Config) when is_list(Config) ->
-    try parse("start -rf", ubiq_cmd())
-    catch error:{argparse, Reason} ->
-        Actual = argparse:format_error(Reason, ubiq_cmd(), #{}),
-        ct:pal("error: ~s", [Actual])
-    end,
-    ok.
-
-meta() ->
-    [{doc, "Tests found while performing meta-testing"}].
-
-%% This test does not verify usage printed,
-%%  but at least ensures formatter does not crash.
-meta(Config) when is_list(Config) ->
-    %% short option with no argument, when it's needed
-    ?assertException(error, {argparse, {missing_argument, _, short49}},
-        parse("-1", #{arguments => [#{name => short49, short => 49}]})),
-    %% extend + maybe
-    ?assertException(error, {argparse, {invalid_option, _, short49, action, _}},
-        parse("-1 -1", #{arguments =>
-        [#{action => extend, name => short49, nargs => 'maybe', short => 49}]})),
-    %%
-    ?assertEqual(#{short49 => 2},
-        parse("-1 arg1 --force", #{arguments =>
-        [#{action => count, long => "-force", name => short49, nargs => 'maybe', short => 49}]})),
-    ok.
+    Expected = "Usage:\n  " ++ prog() ++ " test --req <required>\n\nOptional arguments:\n  --req required\n",
+    ?assertEqual(Expected, unicode:characters_to_list(argparse:help(Cmd, #{command => ["test"]}))).
 
 usage_template() ->
     [{doc, "Tests templates in help/usage"}].
@@ -800,22 +816,22 @@ usage_template(Config) when is_list(Config) ->
     %% Argument (positional)
     Cmd = #{arguments => [#{
         name => shard,
-        type => int,
+        type => integer,
         default => 0,
         help => {"[-s SHARD]", ["initial number, ", type, " with a default value of ", default]}}
     ]},
-    ?assertEqual("usage: " ++ prog() ++ " [-s SHARD]\n\nArguments:\n  shard initial number, int with a default value of 0\n",
-        argparse:help(Cmd, #{})),
+    ?assertEqual("Usage:\n  " ++ prog() ++ " [-s SHARD]\n\nArguments:\n  shard initial number, int with a default value of 0\n",
+        unicode:characters_to_list(argparse:help(Cmd, #{}))),
     %% Optional
     Cmd1 = #{arguments => [#{
         name => shard,
         short => $s,
-        type => int,
+        type => integer,
         default => 0,
         help => {"[-s SHARD]", ["initial number"]}}
     ]},
-    ?assertEqual("usage: " ++ prog() ++ " [-s SHARD]\n\nOptional arguments:\n  -s initial number\n",
-        argparse:help(Cmd1, #{})),
+    ?assertEqual("Usage:\n  " ++ prog() ++ " [-s SHARD]\n\nOptional arguments:\n  -s initial number\n",
+        unicode:characters_to_list(argparse:help(Cmd1, #{}))),
     %% ISO Date example
     DefaultRange = {{2020, 1, 1}, {2020, 6, 22}},
     CmdISO = #{
@@ -833,6 +849,207 @@ usage_template(Config) when is_list(Config) ->
             }
         ]
     },
-    ?assertEqual("usage: " ++ prog() ++ " [--range RNG]\n\nOptional arguments:\n  -r, --range date range, 2020-1-1..2020-6-22\n",
-        argparse:help(CmdISO, #{})),
+    ?assertEqual("Usage:\n  " ++ prog() ++ " [--range RNG]\n\nOptional arguments:\n  -r, --range date range, 2020-1-1..2020-6-22\n",
+        unicode:characters_to_list(argparse:help(CmdISO, #{}))),
     ok.
+
+parser_error_usage() ->
+    [{doc, "Tests that parser errors have corresponding usage text"}].
+
+parser_error_usage(Config) when is_list(Config) ->
+    %% unknown arguments
+    Prog = prog(),
+    ?assertEqual(Prog ++ ": unknown argument: arg", parser_error(["arg"], #{})),
+    ?assertEqual(Prog ++ ": unknown argument: -a", parser_error(["-a"], #{})),
+    %% missing argument
+    ?assertEqual(Prog ++ ": required argument missing: need", parser_error([""],
+        #{arguments => [#{name => need}]})),
+    ?assertEqual(Prog ++ ": required argument missing: need", parser_error([""],
+        #{arguments => [#{name => need, short => $n, required => true}]})),
+    %% invalid value
+    ?assertEqual(Prog ++ ": invalid argument for need: foo is not an integer", parser_error(["foo"],
+        #{arguments => [#{name => need, type => integer}]})),
+    ?assertEqual(Prog ++ ": invalid argument for need: cAnNotExIsT is not an existing atom", parser_error(["cAnNotExIsT"],
+        #{arguments => [#{name => need, type => atom}]})).
+
+command_usage() ->
+    [{doc, "Test command help template"}].
+
+command_usage(Config) when is_list(Config) ->
+    Cmd = #{arguments => [
+        #{name => arg, help => "argument help"}, #{name => opt, short => $o, help => "option help"}],
+        help => ["Options:\n", options, arguments, "NOTAUSAGE", usage, "\n"]
+    },
+    ?assertEqual("Options:\n  -o  option help\n  arg argument help\nNOTAUSAGE  " ++ prog() ++ " [-o <opt>] <arg>\n",
+        unicode:characters_to_list(argparse:help(Cmd, #{}))).
+
+usage_width() ->
+    [{doc, "Test usage fitting in the viewport"}].
+
+usage_width(Config) when is_list(Config) ->
+    Cmd = #{arguments => [
+        #{name => arg, help => "argument help that spans way over allowed viewport width, wrapping words"},
+        #{name => opt, short => $o, long => "-option_long_name",
+            help => "another quite long word wrapped thing spanning over several lines"},
+        #{name => v, short => $v, type => boolean},
+        #{name => q, short => $q, type => boolean}],
+        commands => #{
+            "cmd1" => #{help => "Help for command number 1, not fitting at all"},
+            "cmd2" => #{help => "Short help"},
+            "cmd3" => #{help => "Yet another instance of a very long help message"}
+        },
+        help => "Very long help line taking much more than 40 characters allowed by the test case"
+    },
+
+    Expected = "Usage:\n  " ++ prog() ++ " {cmd1|cmd2|cmd3} [-vq] [-o <opt>]\n"
+        "      [--option_long_name <opt>] <arg>\n\n"
+        "Very long help line taking much more\n"
+        "than 40 characters allowed by the test\n"
+        "case\n\n"
+        "Subcommands:\n"
+        "  cmd1                   Help for\n"
+        "                         command number\n"
+        "                         1, not fitting\n"
+        "                         at all\n"
+        "  cmd2                   Short help\n"
+        "  cmd3                   Yet another\n"
+        "                         instance of a\n"
+        "                         very long help\n"
+        "                         message\n\n"
+        "Arguments:\n"
+        "  arg                    argument help\n"
+        "                         that spans way\n"
+        "                         over allowed\n"
+        "                         viewport width,\n"
+        "                         wrapping words\n\n"
+        "Optional arguments:\n"
+        "  -o, --option_long_name another quite\n"
+        "                         long word\n"
+        "                         wrapped thing\n"
+        "                         spanning over\n"
+        "                         several lines\n"
+        "  -v                     v\n"
+        "  -q                     q\n",
+
+    ?assertEqual(Expected, unicode:characters_to_list(argparse:help(Cmd, #{columns => 40}))).
+
+%%--------------------------------------------------------------------
+%% Validator Test Cases
+
+validator_exception() ->
+    [{doc, "Tests that the validator throws expected exceptions"}].
+
+validator_exception(Config) when is_list(Config) ->
+    Prg = [prog()],
+    %% conflicting option names
+    ?assertException(error, {argparse, argument, Prg, short, "short conflicting with previously defined short for one"},
+        argparse:validate(#{arguments => [#{name => one, short => $$}, #{name => two, short => $$}]})),
+    ?assertException(error, {argparse, argument, Prg, long, "long conflicting with previously defined long for one"},
+        argparse:validate(#{arguments => [#{name => one, long => "a"}, #{name => two, long => "a"}]})),
+    %% broken options
+    %% long must be a string
+    ?assertException(error, {argparse, argument, Prg, long, _},
+        argparse:validate(#{arguments => [#{name => one, long => ok}]})),
+    %% short must be a printable character
+    ?assertException(error, {argparse, argument, Prg, short, _},
+        argparse:validate(#{arguments => [#{name => one, short => ok}]})),
+    ?assertException(error, {argparse, argument, Prg, short, _},
+        argparse:validate(#{arguments => [#{name => one, short => 7}]})),
+    %% required is a boolean
+    ?assertException(error, {argparse, argument, Prg, required, _},
+        argparse:validate(#{arguments => [#{name => one, required => ok}]})),
+    ?assertException(error, {argparse, argument, Prg, help, _},
+        argparse:validate(#{arguments => [#{name => one, help => ok}]})),
+    %% broken commands
+    try argparse:help(#{}, #{progname => 123}), ?assert(false)
+    catch error:badarg:Stack ->
+        [{_, _, _, Ext} | _] = Stack,
+        #{cause := #{2 := Detail}} = proplists:get_value(error_info, Ext),
+        ?assertEqual(<<"progname is not valid">>, Detail)
+    end,
+    %% not-a-list of arguments provided to a subcommand
+    Prog = prog(),
+    ?assertException(error, {argparse, command, [Prog, "start"], arguments, <<"expected a list, [argument()]">>},
+        argparse:validate(#{commands => #{"start" => #{arguments => atom}}})),
+    %% command is not a map
+    ?assertException(error, {argparse, command, Prg, commands, <<"expected map of #{string() => command()}">>},
+        argparse:validate(#{commands => []})),
+    %% invalid commands field
+    ?assertException(error, {argparse, command, Prg, commands, _},
+        argparse:validate(#{commands => ok})),
+    ?assertException(error, {argparse, command, _, commands, _},
+        argparse:validate(#{commands => #{ok => #{}}})),
+    ?assertException(error, {argparse, command, _, help,
+        <<"must be a printable unicode list, or a command help template">>},
+        argparse:validate(#{commands => #{"ok" => #{help => ok}}})),
+    ?assertException(error, {argparse, command, _, handler, _},
+        argparse:validate(#{commands => #{"ok" => #{handler => fun validator_exception/0}}})),
+    %% extend + maybe: validator exception
+    ?assertException(error, {argparse, argument, _, action, <<"extend action works only with lists">>},
+        parse("-1 -1", #{arguments =>
+        [#{action => extend, name => short49, nargs => 'maybe', short => 49}]})).
+
+validator_exception_format() ->
+    [{doc, "Tests human-readable (EEP-54) format for exceptions thrown by the validator"}].
+
+validator_exception_format(Config) when is_list(Config) ->
+    %% set up as a contract: test that EEP-54 transformation is done (but don't check strings)
+    try
+        argparse:validate(#{commands => #{"one" => #{commands => #{"two" => atom}}}}),
+        ?assert(false)
+    catch
+        error:R1:S1 ->
+            #{1 := Cmd, reason := RR1, general := G} = argparse:format_error(R1, S1),
+            ?assertEqual("command specification is invalid", unicode:characters_to_list(G)),
+            ?assertEqual("command \"" ++ prog() ++ " one two\": invalid field 'commands', reason: expected command()",
+                unicode:characters_to_list(RR1)),
+            ?assertEqual(["atom"], Cmd)
+    end,
+    %% check argument
+    try
+        argparse:validate(#{arguments => [#{}]}),
+        ?assert(false)
+    catch
+        error:R2:S2 ->
+            #{1 := Cmd2, reason := RR2, general := G2} = argparse:format_error(R2, S2),
+            ?assertEqual("argument specification is invalid", unicode:characters_to_list(G2)),
+            ?assertEqual("command \"" ++ prog() ++
+                "\", argument '', invalid field 'name': argument must be a map containing 'name' field",
+                unicode:characters_to_list(RR2)),
+            ?assertEqual(["#{}"], Cmd2)
+    end.
+
+%%--------------------------------------------------------------------
+%% Validator Test Cases
+
+run_handle() ->
+    [{doc, "Very basic tests for argparse:run/3, choice of handlers formats"}].
+
+%% fun((arg_map()) -> term()) |    %% handler accepting arg_map
+%% {module(), Fn :: atom()} |      %% handler, accepting arg_map, Fn exported from module()
+%% {fun(() -> term()), term()} |   %% handler, positional form (term() is supplied for omitted args)
+%% {module(), atom(), term()}
+
+run_handle(Config) when is_list(Config) ->
+    %% no subcommand, basic fun handler with argmap
+    ?assertEqual(6,
+        argparse:run(["-i", "3"], #{handler => fun (#{in := Val}) -> Val * 2 end,
+        arguments => [#{name => in, short => $i, type => integer}]}, #{})),
+    %% subcommand, positional fun() handler
+    ?assertEqual(6,
+        argparse:run(["mul", "2", "3"], #{commands => #{"mul" => #{
+            handler => {fun (match, L, R) -> L * R end, match},
+            arguments => [#{name => opt, short => $o},
+                #{name => l, type => integer}, #{name => r, type => integer}]}}},
+        #{})),
+    %% no subcommand, positional module-based function
+    ?assertEqual(6,
+        argparse:run(["2", "3"], #{handler => {erlang, '*', undefined},
+            arguments => [#{name => l, type => integer}, #{name => r, type => integer}]},
+            #{})),
+    %% subcommand, module-based function accepting argmap
+    ?assertEqual([{arg, "arg"}],
+        argparse:run(["map", "arg"], #{commands => #{"map" => #{
+            handler => {maps, to_list},
+            arguments => [#{name => arg}]}}},
+            #{})).


### PR DESCRIPTION
Applications that depend on the old `argparse` behaviour (pre-OTP 26), or those compatible with multiple OTP versions (e.g. `erlperf`) can now depend on the `argparse` application, but rename all mentions of `argparse` to `args`.

Later down the road, when OTP26 is the lowest supported version, `args` can be simply removed (and `argparse` from OTP used).